### PR TITLE
Improved New-PDFText + minor fix for New-PDFImage

### DIFF
--- a/PSWritePDF.psd1
+++ b/PSWritePDF.psd1
@@ -8,7 +8,7 @@
     Description          = 'Little project to create, read, modify, split, merge PDF files on Windows, Linux and Mac.'
     FunctionsToExport    = @('Close-PDF', 'Get-PDF', 'Get-PDFDetails', 'Get-PDFFormField', 'New-PDF', 'New-PDFArea', 'New-PDFDocument', 'New-PDFImage', 'New-PDFInfo', 'New-PDFList', 'New-PDFListItem', 'New-PDFOptions', 'New-PDFPage', 'New-PDFTable', 'New-PDFText', 'Register-PDFFont', 'Get-PDFConstantAction', 'Get-PDFConstantColor', 'Get-PDFConstantFont', 'Get-PDFConstantPageSize', 'Get-PDFConstantVersion', 'Convert-HTMLToPDF', 'Convert-PDFToText', 'Merge-PDF', 'Set-PDFForm', 'Split-PDF')
     GUID                 = '19fcb43c-d8c5-44a9-84e4-bccf29765490'
-    ModuleVersion        = '0.0.20'
+    ModuleVersion        = '0.0.21'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Class.Validations.ps1
+++ b/Private/Class.Validations.ps1
@@ -10,6 +10,18 @@ $Script:PDFFontValidation = {
     )
     $_ -in $Array
 }
+
+$Script:PDFTextAlignments = {
+    ([iText.Layout.Properties.TextAlignment] | Get-Member -static -MemberType Property).Name
+}
+$Script:PDFTextAlignmentValidation = {
+    $Array = @(
+        (& $Script:PDFTextAlignments)
+        ''
+    )
+    $_ -in $Array
+}
+
 $Script:PDFFontList = {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
     @(

--- a/Private/New-InternalPDFImage.ps1
+++ b/Private/New-InternalPDFImage.ps1
@@ -12,10 +12,10 @@
     $Image = [iText.Layout.Element.Image]::new($ImageData)
 
     if ($Width) {
-        $Image.SetWidth($Width)
+        $null = $Image.SetWidth($Width)
     }
     if ($Height) {
-        $Image.SetHeight($Height)
+        $null = $Image.SetHeight($Height)
 
     }
     if ($BackgroundColor) {

--- a/Private/New-InternalPDFText.ps1
+++ b/Private/New-InternalPDFText.ps1
@@ -1,5 +1,4 @@
-﻿function New-InternalPDFText
-{
+﻿function New-InternalPDFText {
     [CmdletBinding()]
     param(
         [string[]] $Text,
@@ -17,72 +16,52 @@
 
     $Paragraph = [iText.Layout.Element.Paragraph]::New()
 
-    if ($FontBold)
-    {
+    if ($FontBold) {
         [Array] $FontBold = $FontBold
         $DefaultBold = $FontBold[0]
     }
-    if ($FontColor)
-    {
+    if ($FontColor) {
         [Array] $FontColor = $FontColor
         $DefaultColor = $FontColor[0]
     }
-    if ($Font)
-    {
+    if ($Font) {
         [Array] $Font = $Font
         $DefaultFont = $Font[0]
     }
 
-    for ($i = 0; $i -lt $Text.Count; $i++)
-    {
+    for ($i = 0; $i -lt $Text.Count; $i++) {
         [iText.Layout.Element.Text] $PDFText = $Text[$i]
 
-        if ($FontBold)
-        {
-            if ($null -ne $FontBold[$i])
-            {
-                if ($FontBold[$i])
-                {
+        if ($FontBold) {
+            if ($null -ne $FontBold[$i]) {
+                if ($FontBold[$i]) {
                     $PDFText = $PDFText.SetBold()
                 }
-            }
-            else
-            {
-                if ($DefaultBold)
-                {
+            } else {
+                if ($DefaultBold) {
                     $PDFText = $PDFText.SetBold()
                 }
             }
         }
-        if ($FontColor)
-        {
-            if ($null -ne $FontColor[$i])
-            {
-                if ($FontColor[$i])
-                {
+        if ($FontColor) {
+            if ($null -ne $FontColor[$i]) {
+                if ($FontColor[$i]) {
                     $ConvertedColor = Get-PDFConstantColor -Color $FontColor[$i]
                     $PDFText = $PDFText.SetFontColor($ConvertedColor)
                 }
-            }
-            else
-            {
-                if ($DefaultColor)
-                {
+            } else {
+                if ($DefaultColor) {
                     $ConvertedColor = Get-PDFConstantColor -Color $DefaultColor
                     $PDFText = $PDFText.SetFontColor($ConvertedColor)
                 }
             }
         }
-        if ($FontSize)
-        {
+        if ($FontSize) {
             $PDFText = $PDFText.SetFontSize($FontSize)
         }
-        if ($Font)
-        {
-            if ($null -ne $Font[$i])
-            {
-                if ($Font[$i])
-                {
+        if ($Font) {
+            if ($null -ne $Font[$i]) {
+                if ($Font[$i]) {
                     #$ConvertedFont = Get-PDFConstantFont -Font $Font[$i]
                     #$ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont($ConvertedFont, [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
                     #$ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont('TIMES_ROMAN', [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
@@ -90,11 +69,8 @@
                     $ApplyFont = Get-InternalPDFFont -Font $Font[$i]
                     $PDFText = $PDFText.SetFont($ApplyFont)
                 }
-            }
-            else
-            {
-                if ($DefaultColor)
-                {
+            } else {
+                if ($DefaultColor) {
                     # $ConvertedFont = Get-PDFConstantFont -Font $DefaultFont
                     # $ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont($ConvertedFont, [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
                     # $PDFText = $PDFText.SetFont($ApplyFont)
@@ -102,29 +78,23 @@
                     $PDFText = $PDFText.SetFont($ApplyFont)
                 }
             }
-        }
-        else
-        {
-            if ($Script:DefaultFont)
-            {
+        } else {
+            if ($Script:DefaultFont) {
                 $PDFText = $PDFText.SetFont($Script:DefaultFont)
             }
         }
         $null = $Paragraph.Add($PDFText)
     }
-    if ($TextAlignment)
-    {
+    if ($TextAlignment) {
         $ConvertedTextAlignment = Get-PDFConstantTextAlignment -TextAlignment $TextAlignment
         $null = $Paragraph.SetTextAlignment($ConvertedTextAlignment)
     }
     $null = $Paragraph.SetMarginTop($MarginTop)
     $null = $Paragraph.SetMarginBottom($MarginBottom)
-    if ($MarginLeft)
-    {
+    if ($MarginLeft) {
         $null = $Paragraph.SetMarginLeft($MarginLeft)
     }
-    if ($MarginRight)
-    {
+    if ($MarginRight) {
         $null = $Paragraph.SetMarginRight($MarginRight)
     }
     $Paragraph

--- a/Private/New-InternalPDFText.ps1
+++ b/Private/New-InternalPDFText.ps1
@@ -1,58 +1,88 @@
-﻿function New-InternalPDFText {
+﻿function New-InternalPDFText
+{
     [CmdletBinding()]
     param(
         [string[]] $Text,
         [ValidateScript( { & $Script:PDFFontValidationList } )][string[]] $Font,
         #[string[]] $FontFamily,
         [ValidateScript( { & $Script:PDFColorValidation } )][string[]] $FontColor,
-        [nullable[bool][]] $FontBold
+        [nullable[bool][]] $FontBold,
+        [int] $FontSize,
+        [string] $TextAlignment,
+        [nullable[float]] $MarginTop,
+        [nullable[float]] $MarginBottom,
+        [nullable[float]] $MarginLeft,
+        [nullable[float]] $MarginRight
     )
 
-    $Paragraph = [iText.Layout.Element.Paragraph]::new()
+    $Paragraph = [iText.Layout.Element.Paragraph]::New()
 
-    if ($FontBold) {
+    if ($FontBold)
+    {
         [Array] $FontBold = $FontBold
         $DefaultBold = $FontBold[0]
     }
-    if ($FontColor) {
+    if ($FontColor)
+    {
         [Array] $FontColor = $FontColor
         $DefaultColor = $FontColor[0]
     }
-    if ($Font) {
+    if ($Font)
+    {
         [Array] $Font = $Font
         $DefaultFont = $Font[0]
     }
 
-    for ($i = 0; $i -lt $Text.Count; $i++) {
+    for ($i = 0; $i -lt $Text.Count; $i++)
+    {
         [iText.Layout.Element.Text] $PDFText = $Text[$i]
 
-        if ($FontBold) {
-            if ($null -ne $FontBold[$i]) {
-                if ($FontBold[$i]) {
+        if ($FontBold)
+        {
+            if ($null -ne $FontBold[$i])
+            {
+                if ($FontBold[$i])
+                {
                     $PDFText = $PDFText.SetBold()
                 }
-            } else {
-                if ($DefaultBold) {
+            }
+            else
+            {
+                if ($DefaultBold)
+                {
                     $PDFText = $PDFText.SetBold()
                 }
             }
         }
-        if ($FontColor) {
-            if ($null -ne $FontColor[$i]) {
-                if ($FontColor[$i]) {
+        if ($FontColor)
+        {
+            if ($null -ne $FontColor[$i])
+            {
+                if ($FontColor[$i])
+                {
                     $ConvertedColor = Get-PDFConstantColor -Color $FontColor[$i]
                     $PDFText = $PDFText.SetFontColor($ConvertedColor)
                 }
-            } else {
-                if ($DefaultColor) {
+            }
+            else
+            {
+                if ($DefaultColor)
+                {
                     $ConvertedColor = Get-PDFConstantColor -Color $DefaultColor
                     $PDFText = $PDFText.SetFontColor($ConvertedColor)
                 }
             }
         }
-        if ($Font) {
-            if ($null -ne $Font[$i]) {
-                if ($Font[$i]) {
+        if ($FontSize)
+        {
+            $PDFText = $PDFText.SetFontSize($FontSize)
+        }
+        if ($Font)
+        {
+            if ($null -ne $Font[$i])
+            {
+                if ($Font[$i])
+                {
                     #$ConvertedFont = Get-PDFConstantFont -Font $Font[$i]
                     #$ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont($ConvertedFont, [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
                     #$ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont('TIMES_ROMAN', [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
@@ -60,8 +90,11 @@
                     $ApplyFont = Get-InternalPDFFont -Font $Font[$i]
                     $PDFText = $PDFText.SetFont($ApplyFont)
                 }
-            } else {
-                if ($DefaultColor) {
+            }
+            else
+            {
+                if ($DefaultColor)
+                {
                     # $ConvertedFont = Get-PDFConstantFont -Font $DefaultFont
                     # $ApplyFont = [iText.Kernel.Font.PdfFontFactory]::CreateFont($ConvertedFont, [iText.IO.Font.PdfEncodings]::IDENTITY_H, $false)
                     # $PDFText = $PDFText.SetFont($ApplyFont)
@@ -69,12 +102,30 @@
                     $PDFText = $PDFText.SetFont($ApplyFont)
                 }
             }
-        } else {
-            if ($Script:DefaultFont) {
+        }
+        else
+        {
+            if ($Script:DefaultFont)
+            {
                 $PDFText = $PDFText.SetFont($Script:DefaultFont)
             }
         }
         $null = $Paragraph.Add($PDFText)
+    }
+    if ($TextAlignment)
+    {
+        $ConvertedTextAlignment = Get-PDFConstantTextAlignment -TextAlignment $TextAlignment
+        $null = $Paragraph.SetTextAlignment($ConvertedTextAlignment)
+    }
+    $null = $Paragraph.SetMarginTop($MarginTop)
+    $null = $Paragraph.SetMarginBottom($MarginBottom)
+    if ($MarginLeft)
+    {
+        $null = $Paragraph.SetMarginLeft($MarginLeft)
+    }
+    if ($MarginRight)
+    {
+        $null = $Paragraph.SetMarginRight($MarginRight)
     }
     $Paragraph
 }

--- a/Public/Constants/Get-PDFConstantTextAlignment.ps1
+++ b/Public/Constants/Get-PDFConstantTextAlignment.ps1
@@ -1,0 +1,14 @@
+# Validation for Colors
+$Script:PDFTextAlignments = {
+    ([iText.Layout.Properties.TextAlignment] | Get-Member -static -MemberType Property).Name
+}
+
+function Get-PDFConstantTextAlignment {
+    [CmdletBinding()]
+    param(
+        [ValidateScript( { & $Script:PDFTextAlignmentValidation } )][string] $TextAlignment
+    )
+    return [iText.Layout.Properties.TextAlignment]::$TextAlignment
+}
+
+Register-ArgumentCompleter -CommandName Get-PDFConstantTextAlignment -ParameterName TextAlignment -ScriptBlock $Script:PDFTextAlignments

--- a/Public/New-PDFText.ps1
+++ b/Public/New-PDFText.ps1
@@ -4,7 +4,13 @@
         [string[]] $Text,
         [ValidateScript( { & $Script:PDFFontValidationList } )][string[]] $Font,
         [ValidateScript( { & $Script:PDFColorValidation } )][string[]] $FontColor,
-        [nullable[bool][]] $FontBold
+        [nullable[bool][]] $FontBold,
+        [int] $FontSize,
+        [ValidateScript( { & $Script:PDFTextAlignmentValidation } )][string] $TextAlignment,
+        [nullable[float]] $MarginTop = 2,
+        [nullable[float]] $MarginBottom = 2,
+        [nullable[float]] $MarginLeft,
+        [nullable[float]] $MarginRight
     )
     $Splat = @{ }
     if ($Text) {
@@ -18,6 +24,24 @@
     }
     if ($FontBold) {
         $Splat['FontBold'] = $FontBold
+    }
+    if ($FontSize) {
+        $Splat['FontSize'] = $FontSize
+    }
+    if ($TextAlignment) {
+        $Splat['TextAlignment'] = $TextAlignment
+    }
+    if ($MarginTop) {
+        $Splat['MarginTop'] = $MarginTop
+    }
+    if ($MarginBottom) {
+        $Splat['MarginBottom'] = $MarginBottom
+    }
+    if ($MarginLeft) {
+        $Splat['MarginLeft'] = $MarginLeft
+    }
+    if ($MarginRight) {
+        $Splat['MarginRight'] = $MarginRight
     }
 
     if ($null -ne $Script:PDFStart -and $Script:PDFStart['Start']) {
@@ -33,3 +57,4 @@
 
 Register-ArgumentCompleter -CommandName New-PDFText -ParameterName Font -ScriptBlock $Script:PDFFontList
 Register-ArgumentCompleter -CommandName New-PDFText -ParameterName FontColor -ScriptBlock $Script:PDFColor
+Register-ArgumentCompleter -CommandName New-PDFText -ParameterName HorizontalAlignment -ScriptBlock $Script:PDFTextAlignments


### PR DESCRIPTION
New-PDFText now allows to specify the font size and specify a margin around the text, which both is useful for adding a heading. 
New-PDFImage had a bug, where the object type was output, when the internal cmdlet set the width and height. I fixed that by sending it to null, which is the way, it was done in the other occassions in the script. 