### PR TITLE
Add PdfIMO library with iText 9 support and tests

### DIFF
--- a/Example/Example13.PdfIMO/Example13_PdfIMOSimple.cs
+++ b/Example/Example13.PdfIMO/Example13_PdfIMOSimple.cs
@@ -1,0 +1,3 @@
+using PdfIMO;
+
+PdfGenerator.CreateSimplePdf("Example13_PdfIMOSimple.pdf");

--- a/Sources/PSWritePDF.sln
+++ b/Sources/PSWritePDF.sln
@@ -5,24 +5,56 @@ VisualStudioVersion = 17.3.32804.467
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PSWritePDF", "PSWritePDF\PSWritePDF.csproj", "{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfIMO", "PdfIMO\PdfIMO.csproj", "{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfIMO.Tests", "PdfIMO.Tests\PdfIMO.Tests.csproj", "{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|x64.Build.0 = Debug|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Debug|x86.Build.0 = Debug|Any CPU
 		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7391AC3E-2156-49C6-A228-15B6A7946FBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7391AC3E-2156-49C6-A228-15B6A7946FBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7391AC3E-2156-49C6-A228-15B6A7946FBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7391AC3E-2156-49C6-A228-15B6A7946FBA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C3349FCA-EF1E-4AFF-8F4C-522530B18D54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C3349FCA-EF1E-4AFF-8F4C-522530B18D54}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C3349FCA-EF1E-4AFF-8F4C-522530B18D54}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C3349FCA-EF1E-4AFF-8F4C-522530B18D54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|x64.ActiveCfg = Release|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|x64.Build.0 = Release|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}.Release|x86.Build.0 = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|x64.Build.0 = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFC88781-45A7-4A0E-9198-3C67CABDF4C1}.Release|x86.Build.0 = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x64.Build.0 = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/PSWritePDF/PSWritePDF.csproj
+++ b/Sources/PSWritePDF/PSWritePDF.csproj
@@ -12,9 +12,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="itext7" Version="8.0.5" />
-		<PackageReference Include="itext7.font-asian" Version="8.0.5" />
-		<PackageReference Include="itext7.pdfhtml" Version="5.0.5" />
+                <PackageReference Include="itext7" Version="9.2.0" />
+                <PackageReference Include="itext7.font-asian" Version="9.2.0" />
+                <PackageReference Include="itext7.pdfhtml" Version="6.2.0" />
 		<PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
 		<PackageReference Include="System.Management" Version="7.0.2" PrivateAssets="all" />
 	</ItemGroup>

--- a/Sources/PdfIMO.Tests/PdfGeneratorTests.cs
+++ b/Sources/PdfIMO.Tests/PdfGeneratorTests.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Text;
+using PdfIMO;
+using Xunit;
+
+namespace PdfIMO.Tests
+{
+    public class PdfGeneratorTests
+    {
+        [Fact]
+        public void CreateSimplePdf_CreatesFileWithPdfHeader()
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                PdfGenerator.CreateSimplePdf(tempFile);
+                Assert.True(File.Exists(tempFile));
+                using var stream = File.OpenRead(tempFile);
+                var buffer = new byte[4];
+                _ = stream.Read(buffer, 0, buffer.Length);
+                Assert.Equal("%PDF", Encoding.ASCII.GetString(buffer));
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+        }
+    }
+}

--- a/Sources/PdfIMO.Tests/PdfIMO.Tests.csproj
+++ b/Sources/PdfIMO.Tests/PdfIMO.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PdfIMO\PdfIMO.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/PdfIMO/Core/PdfGenerator.cs
+++ b/Sources/PdfIMO/Core/PdfGenerator.cs
@@ -1,0 +1,17 @@
+using iText.Kernel.Pdf;
+using iText.Layout;
+using iText.Layout.Element;
+
+namespace PdfIMO
+{
+    public static class PdfGenerator
+    {
+        public static void CreateSimplePdf(string path)
+        {
+            using var writer = new PdfWriter(path);
+            using var pdf = new PdfDocument(writer);
+            using var document = new Document(pdf);
+            document.Add(new Paragraph("Hello from PdfIMO"));
+        }
+    }
+}

--- a/Sources/PdfIMO/PdfIMO.csproj
+++ b/Sources/PdfIMO/PdfIMO.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>net472;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <AssemblyName>PdfIMO</AssemblyName>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="itext7" Version="9.2.0" />
+    <PackageReference Include="itext7.font-asian" Version="9.2.0" />
+    <PackageReference Include="itext7.pdfhtml" Version="6.2.0" />
+    <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.2.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add PdfIMO class library targeting net472, netstandard2.0, net8.0, and net9.0
- wire up iText9 dependencies across PdfIMO and PSWritePDF
- add example and xUnit tests for PdfIMO

## Testing
- `dotnet build Sources/PSWritePDF.sln`
- `dotnet test Sources/PSWritePDF.sln`


------
https://chatgpt.com/codex/tasks/task_e_688fa22ccebc832ead975df210bfe641