### PR TITLE
Add C# builders for PDF elements

### DIFF
--- a/Example/Example13.PdfIMO/Example13_PdfIMOSimple.cs
+++ b/Example/Example13.PdfIMO/Example13_PdfIMOSimple.cs
@@ -1,3 +1,0 @@
-using PdfIMO;
-
-PdfGenerator.CreateSimplePdf("Example13_PdfIMOSimple.pdf");

--- a/Sources/PSWritePDF.sln
+++ b/Sources/PSWritePDF.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfIMO", "PdfIMO\PdfIMO.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfIMO.Tests", "PdfIMO.Tests\PdfIMO.Tests.csproj", "{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfIMO.Examples", "PdfIMO.Examples\PdfIMO.Examples.csproj", "{D12AF663-6DAA-492F-B885-E0D1C91B60EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x64.Build.0 = Release|Any CPU
 		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x86.ActiveCfg = Release|Any CPU
 		{2E5D3BC2-A41A-45A0-BC4E-35922AAF1024}.Release|x86.Build.0 = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|x64.Build.0 = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{D12AF663-6DAA-492F-B885-E0D1C91B60EA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/PdfIMO.Examples/BuildersExample.cs
+++ b/Sources/PdfIMO.Examples/BuildersExample.cs
@@ -1,0 +1,24 @@
+using iText.Kernel.Pdf;
+using iText.Layout.Properties;
+using PdfIMO;
+
+namespace PdfIMO.Examples;
+
+public static class BuildersExample
+{
+    public static void Run()
+    {
+        var path = "Example13_PdfIMOBuilders.pdf";
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        using var document = PdfPage.AddPage(pdf, PdfPageSize.A4, marginLeft: 20, marginRight: 20);
+        var paragraph = PdfText.CreateParagraph(
+            new[] { "Hello PdfIMO Builders" },
+            new[] { PdfFontName.HELVETICA },
+            new[] { PdfColor.Red },
+            14,
+            TextAlignment.CENTER);
+        document.Add(paragraph);
+        document.Close();
+    }
+}

--- a/Sources/PdfIMO.Examples/PdfIMO.Examples.csproj
+++ b/Sources/PdfIMO.Examples/PdfIMO.Examples.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PdfIMO\PdfIMO.csproj" />
+  </ItemGroup>
+</Project>

--- a/Sources/PdfIMO.Examples/Program.cs
+++ b/Sources/PdfIMO.Examples/Program.cs
@@ -1,0 +1,10 @@
+namespace PdfIMO.Examples;
+
+internal static class Program
+{
+    static void Main()
+    {
+        SimpleExample.Run();
+        BuildersExample.Run();
+    }
+}

--- a/Sources/PdfIMO.Examples/SimpleExample.cs
+++ b/Sources/PdfIMO.Examples/SimpleExample.cs
@@ -1,0 +1,11 @@
+using PdfIMO;
+
+namespace PdfIMO.Examples;
+
+public static class SimpleExample
+{
+    public static void Run()
+    {
+        PdfGenerator.CreateSimplePdf("Example13_PdfIMOSimple.pdf");
+    }
+}

--- a/Sources/PdfIMO.Tests/PdfBuildersTests.cs
+++ b/Sources/PdfIMO.Tests/PdfBuildersTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Text;
+using iText.Kernel.Pdf;
+using PdfIMO;
+using iText.Layout.Properties;
+using Xunit;
+
+namespace PdfIMO.Tests
+{
+    public class PdfBuildersTests
+    {
+        [Fact]
+        public void TextAndPageBuilders_CreatePdfWithParagraph()
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                using var writer = new PdfWriter(tempFile);
+                using var pdf = new PdfDocument(writer);
+                using var document = PdfPage.AddPage(pdf, PdfPageSize.A4, marginLeft: 10, marginRight: 10);
+
+                var paragraph = PdfText.CreateParagraph(
+                    new[] { "Hello from builders" },
+                    new[] { PdfFontName.HELVETICA },
+                    new[] { PdfColor.Blue },
+                    12,
+                    TextAlignment.CENTER);
+
+                document.Add(paragraph);
+                document.Close();
+
+                Assert.True(File.Exists(tempFile));
+                using var stream = File.OpenRead(tempFile);
+                var buffer = new byte[4];
+                _ = stream.Read(buffer, 0, buffer.Length);
+                Assert.Equal("%PDF", Encoding.ASCII.GetString(buffer));
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfEnums.cs
+++ b/Sources/PdfIMO/Core/PdfEnums.cs
@@ -1,0 +1,43 @@
+namespace PdfIMO
+{
+    public enum PdfFontName
+    {
+        COURIER,
+        COURIER_BOLD,
+        COURIER_OBLIQUE,
+        COURIER_BOLDOBLIQUE,
+        HELVETICA,
+        HELVETICA_BOLD,
+        HELVETICA_OBLIQUE,
+        HELVETICA_BOLDOBLIQUE,
+        SYMBOL,
+        TIMES_ROMAN,
+        TIMES_BOLD,
+        TIMES_ITALIC,
+        TIMES_BOLDITALIC,
+        ZAPFDINGBATS
+    }
+
+    public enum PdfColor
+    {
+        Black,
+        Blue,
+        Red,
+        Green,
+        Gray
+    }
+
+    public enum PdfPageSize
+    {
+        Default,
+        A4,
+        Letter,
+        Legal
+    }
+
+    public enum ListSymbol
+    {
+        Hyphen,
+        Bullet
+    }
+}

--- a/Sources/PdfIMO/Core/PdfHelpers.cs
+++ b/Sources/PdfIMO/Core/PdfHelpers.cs
@@ -1,0 +1,48 @@
+using System;
+using iText.IO.Font.Constants;
+using iText.Kernel.Colors;
+using iText.Kernel.Font;
+using iText.Kernel.Geom;
+
+namespace PdfIMO
+{
+    internal static class PdfHelpers
+    {
+        public static PdfFont CreateFont(PdfFontName font) => PdfFontFactory.CreateFont(font switch
+        {
+            PdfFontName.COURIER => StandardFonts.COURIER,
+            PdfFontName.COURIER_BOLD => StandardFonts.COURIER_BOLD,
+            PdfFontName.COURIER_OBLIQUE => StandardFonts.COURIER_OBLIQUE,
+            PdfFontName.COURIER_BOLDOBLIQUE => StandardFonts.COURIER_BOLDOBLIQUE,
+            PdfFontName.HELVETICA => StandardFonts.HELVETICA,
+            PdfFontName.HELVETICA_BOLD => StandardFonts.HELVETICA_BOLD,
+            PdfFontName.HELVETICA_OBLIQUE => StandardFonts.HELVETICA_OBLIQUE,
+            PdfFontName.HELVETICA_BOLDOBLIQUE => StandardFonts.HELVETICA_BOLDOBLIQUE,
+            PdfFontName.SYMBOL => StandardFonts.SYMBOL,
+            PdfFontName.TIMES_ROMAN => StandardFonts.TIMES_ROMAN,
+            PdfFontName.TIMES_BOLD => StandardFonts.TIMES_BOLD,
+            PdfFontName.TIMES_ITALIC => StandardFonts.TIMES_ITALIC,
+            PdfFontName.TIMES_BOLDITALIC => StandardFonts.TIMES_BOLDITALIC,
+            PdfFontName.ZAPFDINGBATS => StandardFonts.ZAPFDINGBATS,
+            _ => throw new ArgumentOutOfRangeException(nameof(font), font, null)
+        });
+
+        public static Color GetColor(PdfColor color) => color switch
+        {
+            PdfColor.Black => ColorConstants.BLACK,
+            PdfColor.Blue => ColorConstants.BLUE,
+            PdfColor.Red => ColorConstants.RED,
+            PdfColor.Green => ColorConstants.GREEN,
+            PdfColor.Gray => ColorConstants.GRAY,
+            _ => ColorConstants.BLACK
+        };
+
+        public static PageSize GetPageSize(PdfPageSize size) => size switch
+        {
+            PdfPageSize.A4 => PageSize.A4,
+            PdfPageSize.Letter => PageSize.LETTER,
+            PdfPageSize.Legal => PageSize.LEGAL,
+            _ => PageSize.A4
+        };
+    }
+}

--- a/Sources/PdfIMO/Core/PdfImage.cs
+++ b/Sources/PdfIMO/Core/PdfImage.cs
@@ -1,0 +1,36 @@
+using iText.IO.Image;
+using iText.Layout;
+using iText.Layout.Element;
+
+namespace PdfIMO
+{
+    public static class PdfImage
+    {
+        public static void AddImage(
+            Document document,
+            string imagePath,
+            int? width = null,
+            int? height = null,
+            PdfColor? backgroundColor = null,
+            double? backgroundColorOpacity = null)
+        {
+            var imageData = ImageDataFactory.Create(imagePath);
+            var image = new Image(imageData);
+
+            if (width.HasValue) image.SetWidth(width.Value);
+            if (height.HasValue) image.SetHeight(height.Value);
+
+            if (backgroundColor.HasValue)
+            {
+                var rgb = PdfHelpers.GetColor(backgroundColor.Value);
+                image.SetBackgroundColor(rgb);
+                if (backgroundColorOpacity.HasValue)
+                {
+                    image.SetOpacity((float)backgroundColorOpacity.Value);
+                }
+            }
+
+            document.Add(image);
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfList.cs
+++ b/Sources/PdfIMO/Core/PdfList.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using iText.Layout;
+using iText.Layout.Element;
+
+namespace PdfIMO
+{
+    public static class PdfList
+    {
+        public static void AddList(
+            Document document,
+            IEnumerable<string> items,
+            float? indent = null,
+            ListSymbol symbol = ListSymbol.Hyphen,
+            PdfFontName? font = null,
+            PdfColor? fontColor = null,
+            int? fontSize = null,
+            iText.Layout.Properties.TextAlignment? textAlignment = null,
+            float? marginTop = null,
+            float? marginBottom = null,
+            float? marginLeft = null,
+            float? marginRight = null)
+        {
+            var list = new List();
+            if (indent.HasValue)
+            {
+                list.SetSymbolIndent(indent.Value);
+            }
+            if (symbol == ListSymbol.Bullet)
+            {
+                list.SetListSymbol("\u2022");
+            }
+
+            foreach (var item in items)
+            {
+                var paragraph = PdfText.CreateParagraph(
+                    new[] { item },
+                    font.HasValue ? new[] { font.Value } : null,
+                    fontColor.HasValue ? new[] { fontColor.Value } : null,
+                    fontSize,
+                    textAlignment,
+                    marginTop,
+                    marginBottom,
+                    marginLeft,
+                    marginRight);
+                var listItem = new ListItem();
+                listItem.Add(paragraph);
+                list.Add(listItem);
+            }
+
+            document.Add(list);
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfOptions.cs
+++ b/Sources/PdfIMO/Core/PdfOptions.cs
@@ -1,0 +1,25 @@
+using iText.Layout;
+
+namespace PdfIMO
+{
+    public static class PdfOptions
+    {
+        public static void Apply(
+            Document document,
+            float? marginLeft = null,
+            float? marginRight = null,
+            float? marginTop = null,
+            float? marginBottom = null)
+        {
+            if (document == null)
+            {
+                return;
+            }
+
+            if (marginLeft.HasValue) document.SetLeftMargin(marginLeft.Value);
+            if (marginRight.HasValue) document.SetRightMargin(marginRight.Value);
+            if (marginTop.HasValue) document.SetTopMargin(marginTop.Value);
+            if (marginBottom.HasValue) document.SetBottomMargin(marginBottom.Value);
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfPage.cs
+++ b/Sources/PdfIMO/Core/PdfPage.cs
@@ -1,0 +1,35 @@
+using iText.Kernel.Geom;
+using iText.Kernel.Pdf;
+using iText.Layout;
+
+namespace PdfIMO
+{
+    public static class PdfPage
+    {
+        public static Document AddPage(
+            PdfDocument pdf,
+            PdfPageSize pageSize = PdfPageSize.Default,
+            bool rotate = false,
+            float? marginLeft = null,
+            float? marginRight = null,
+            float? marginTop = null,
+            float? marginBottom = null)
+        {
+            PageSize size = PdfHelpers.GetPageSize(pageSize);
+            if (rotate)
+            {
+                size = size.Rotate();
+            }
+
+            pdf.AddNewPage(size);
+            var document = new Document(pdf);
+
+            if (marginLeft.HasValue) document.SetLeftMargin(marginLeft.Value);
+            if (marginRight.HasValue) document.SetRightMargin(marginRight.Value);
+            if (marginTop.HasValue) document.SetTopMargin(marginTop.Value);
+            if (marginBottom.HasValue) document.SetBottomMargin(marginBottom.Value);
+
+            return document;
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfTable.cs
+++ b/Sources/PdfIMO/Core/PdfTable.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using iText.Layout.Element;
+
+namespace PdfIMO
+{
+    public static class PdfTable
+    {
+        public static Table BuildTable<T>(IEnumerable<T> data)
+        {
+            var list = data.ToList();
+            if (!list.Any())
+            {
+                return new Table(1);
+            }
+
+            var properties = typeof(T).GetProperties();
+            var table = new Table(properties.Length).UseAllAvailableWidth();
+
+            foreach (var prop in properties)
+            {
+                var headerParagraph = PdfText.CreateParagraph(new[] { prop.Name });
+                table.AddHeaderCell(new Cell().Add(headerParagraph));
+            }
+
+            foreach (var item in list)
+            {
+                foreach (var prop in properties)
+                {
+                    var value = prop.GetValue(item)?.ToString() ?? string.Empty;
+                    var paragraph = PdfText.CreateParagraph(new[] { value });
+                    table.AddCell(new Cell().Add(paragraph));
+                }
+            }
+
+            return table;
+        }
+    }
+}

--- a/Sources/PdfIMO/Core/PdfText.cs
+++ b/Sources/PdfIMO/Core/PdfText.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using iText.Kernel.Colors;
+using iText.Kernel.Font;
+using iText.Layout.Element;
+using iText.Layout.Properties;
+
+namespace PdfIMO
+{
+    public static class PdfText
+    {
+        public static Paragraph CreateParagraph(
+            IEnumerable<string> text,
+            IEnumerable<PdfFontName> fonts = null,
+            IEnumerable<PdfColor> fontColors = null,
+            int? fontSize = null,
+            TextAlignment? textAlignment = null,
+            float? marginTop = null,
+            float? marginBottom = null,
+            float? marginLeft = null,
+            float? marginRight = null)
+        {
+            var paragraph = new Paragraph();
+            var texts = text?.ToList() ?? new List<string>();
+            var fontList = fonts?.ToList();
+            var colorList = fontColors?.ToList();
+
+            for (int i = 0; i < texts.Count; i++)
+            {
+                Text pdfText = new Text(texts[i]);
+
+                if (fontList != null && fontList.Count > 0)
+                {
+                    var font = fontList.Count > i ? fontList[i] : fontList[0];
+                    PdfFont pdfFont = PdfHelpers.CreateFont(font);
+                    pdfText.SetFont(pdfFont);
+                }
+
+                if (colorList != null && colorList.Count > 0)
+                {
+                    var color = colorList.Count > i ? colorList[i] : colorList[0];
+                    Color converted = PdfHelpers.GetColor(color);
+                    pdfText.SetFontColor(converted);
+                }
+
+                if (fontSize.HasValue)
+                {
+                    pdfText.SetFontSize(fontSize.Value);
+                }
+
+                paragraph.Add(pdfText);
+            }
+
+            if (textAlignment.HasValue)
+            {
+                paragraph.SetTextAlignment(textAlignment.Value);
+            }
+            if (marginTop.HasValue) paragraph.SetMarginTop(marginTop.Value);
+            if (marginBottom.HasValue) paragraph.SetMarginBottom(marginBottom.Value);
+            if (marginLeft.HasValue) paragraph.SetMarginLeft(marginLeft.Value);
+            if (marginRight.HasValue) paragraph.SetMarginRight(marginRight.Value);
+            return paragraph;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add enums for fonts, colors, page sizes, and list symbols
- implement builders for text, pages, images, lists, tables, and options using iText
- provide unit tests and example using new PDF builders
- create PdfIMO.Examples console project with separate example files

## Testing
- `dotnet test Sources/PSWritePDF.sln`

------
https://chatgpt.com/codex/tasks/task_e_688fa8c6f2c4832ea4a9c8e7f757f956