### PR TITLE
Validate image path and return image object from New-PDFImage

### DIFF
--- a/Example/Example09.Images/Example09-Images02.ps1
+++ b/Example/Example09.Images/Example09-Images02.ps1
@@ -1,0 +1,17 @@
+Import-Module .\PSWritePDF.psd1 -Force
+
+# Example showing returned image object
+New-PDF {
+    $img = New-PDFImage -ImagePath "$PSScriptRoot\Evotec-Logo-600x190.png"
+    Write-Host "Image type: $($img.GetType().FullName)"
+} -FilePath "$PSScriptRoot\Example09-Images02.pdf" -Show
+
+# Example handling missing image path
+try {
+    New-PDF {
+        New-PDFImage -ImagePath "$PSScriptRoot\Missing.png"
+    } -FilePath "$PSScriptRoot\Example09-Images-Missing.pdf" -Show
+} catch {
+    Write-Warning $_.Exception.Message
+}
+

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Management.Automation;
 using iText.Layout;
 using PdfIMO;
@@ -14,9 +15,18 @@ public class CmdletNewPDFImage : PSCmdlet {
     [Parameter] public double? BackgroundColorOpacity { get; set; }
 
     protected override void ProcessRecord() {
+        if (!File.Exists(ImagePath)) {
+            var message = $"Image file '{ImagePath}' was not found.";
+            var exception = new FileNotFoundException(message, ImagePath);
+            var errorRecord = new ErrorRecord(exception, "ImageNotFound", ErrorCategory.ObjectNotFound, ImagePath);
+            ThrowTerminatingError(errorRecord);
+            return;
+        }
+
         var document = SessionState.PSVariable.GetValue("Document") as Document;
         if (document != null) {
-            PdfImage.AddImage(document, ImagePath, Width, Height, BackgroundColor, BackgroundColorOpacity);
+            var image = PdfImage.AddImage(document, ImagePath, Width, Height, BackgroundColor, BackgroundColorOpacity);
+            WriteObject(image);
         }
     }
 }

--- a/Sources/PdfIMO/Core/PdfImage.cs
+++ b/Sources/PdfIMO/Core/PdfImage.cs
@@ -6,7 +6,7 @@ namespace PdfIMO
 {
     public static class PdfImage
     {
-        public static void AddImage(
+        public static Image AddImage(
             Document document,
             string imagePath,
             int? width = null,
@@ -31,6 +31,7 @@ namespace PdfIMO
             }
 
             document.Add(image);
+            return image;
         }
     }
 }

--- a/Tests/New-PDFImage.Tests.ps1
+++ b/Tests/New-PDFImage.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'New-PDFImage' {
+    BeforeAll {
+        New-Item -Path $PSScriptRoot -Force -ItemType Directory -Name 'Output' | Out-Null
+    }
+
+    It 'returns image object for existing path' {
+        $imagePath = Join-Path $PSScriptRoot 'Input' 'TestImage.png'
+        [IO.File]::WriteAllBytes($imagePath, [Convert]::FromBase64String('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAAoAAQUBAO9pAAAAAElFTkSuQmCC'))
+
+        $pdfPath = Join-Path $PSScriptRoot 'Output' 'ImageValid.pdf'
+        $image = New-PDF {
+            New-PDFImage -ImagePath $imagePath
+        } -FilePath $pdfPath
+
+        $image | Should -BeOfType 'iText.Layout.Element.Image'
+
+        Remove-Item -LiteralPath $imagePath -ErrorAction SilentlyContinue
+    }
+
+    It 'throws for missing image path' {
+        $missingPath = Join-Path $PSScriptRoot 'Input' 'Missing.png'
+        $pdfPath = Join-Path $PSScriptRoot 'Output' 'ImageMissing.pdf'
+
+        { New-PDF { New-PDFImage -ImagePath $missingPath } -FilePath $pdfPath } | Should -Throw -ErrorId 'ImageNotFound'
+    }
+
+    AfterAll {
+        $folderPath = Join-Path $PSScriptRoot 'Output'
+        Get-ChildItem -Path $folderPath -File | Remove-Item -ErrorAction SilentlyContinue
+    }
+}
+


### PR DESCRIPTION
## Summary
- Validate that `ImagePath` exists before adding image and return the created image object
- Add Pester tests for valid and invalid image paths
- Provide usage examples for retrieving the created image and handling missing files

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pwsh -NoLogo -NoProfile -File ./PSWritePDF.Tests.ps1` *(fails: Importing module PSWritePDF failed due to missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68932f6e0040832ea9a39f033d432ce7