### PR TITLE
Add Force option and ShouldProcess to HTML conversion cmdlet

### DIFF
--- a/Example/Example10.ConvertFromHTML/Example10-FromFilePath.ps1
+++ b/Example/Example10.ConvertFromHTML/Example10-FromFilePath.ps1
@@ -4,4 +4,5 @@ New-HTML {
     New-HTMLTable -DataTable (Get-Process | Select-Object -First 3)
 } -FilePath "$PSScriptRoot\Example10-FromFilePath.html" -Online
 
-Convert-HTMLToPDF -FilePath "$PSScriptRoot\Example10-FromFilePath.html" -OutputFilePath "$PSScriptRoot\Example10-FromFilePath.pdf" -Open
+$output = Convert-HTMLToPDF -FilePath "$PSScriptRoot\Example10-FromFilePath.html" -OutputFilePath "$PSScriptRoot\Example10-FromFilePath.pdf" -Force -Open
+Write-Host "PDF saved to $output"

--- a/Example/Example10.ConvertFromHTML/Example10-FromHTML.ps1
+++ b/Example/Example10.ConvertFromHTML/Example10-FromHTML.ps1
@@ -5,4 +5,5 @@ $HTMLInput = New-HTML {
     New-HTMLTable -DataTable (Get-Process | Select-Object -First 3)
 }
 
-Convert-HTMLToPDF -Content $HTMLInput -OutputFilePath "$PSScriptRoot\Example10-FromHTML.pdf" -Open
+$output = Convert-HTMLToPDF -Content $HTMLInput -OutputFilePath "$PSScriptRoot\Example10-FromHTML.pdf" -Force -Open
+Write-Host "PDF saved to $output"

--- a/Example/Example10.ConvertFromHTML/Example10-FromUri.ps1
+++ b/Example/Example10.ConvertFromHTML/Example10-FromUri.ps1
@@ -1,3 +1,4 @@
-﻿Import-Module .\PSWritePDF.psd1 -Force
+Import-Module .\PSWritePDF.psd1 -Force
 
-Convert-HTMLToPDF -Uri 'https://evotec.xyz/hub/scripts/pswritehtml-powershell-module/' -OutputFilePath "$PSScriptRoot\Example10-FromURL.pdf" -Open
+$output = Convert-HTMLToPDF -Uri 'https://evotec.xyz/hub/scripts/pswritehtml-powershell-module/' -OutputFilePath "$PSScriptRoot\Example10-FromURL.pdf" -Force -Open
+Write-Host "PDF saved to $output"

--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 
 namespace PSWritePDF.Cmdlets;
 
-[Cmdlet(VerbsData.Convert, "HTMLToPDF", DefaultParameterSetName = ParameterSetNames.Uri)]
+[Cmdlet(VerbsData.Convert, "HTMLToPDF", DefaultParameterSetName = ParameterSetNames.Uri, SupportsShouldProcess = true)]
 public class CmdletConvertHTMLToPDF : PSCmdlet
 {
     private static class ParameterSetNames
@@ -29,6 +29,9 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
 
     [Parameter]
     public SwitchParameter Open { get; set; }
+
+    [Parameter]
+    public SwitchParameter Force { get; set; }
 
     protected override void ProcessRecord()
     {
@@ -62,6 +65,17 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
             return;
         }
 
+        if (File.Exists(OutputFilePath) && !Force.IsPresent)
+        {
+            WriteWarning($"File '{OutputFilePath}' already exists. Use -Force to overwrite.");
+            return;
+        }
+
+        if (!ShouldProcess(OutputFilePath, "Convert HTML to PDF"))
+        {
+            return;
+        }
+
         try
         {
             using var fs = new FileStream(OutputFilePath, FileMode.Create, FileAccess.Write);
@@ -75,6 +89,8 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
                 };
                 System.Diagnostics.Process.Start(psi);
             }
+
+            WriteObject(OutputFilePath);
         }
         catch (Exception ex)
         {

--- a/Tests/Convert-HTMLToPDF.Tests.ps1
+++ b/Tests/Convert-HTMLToPDF.Tests.ps1
@@ -3,10 +3,22 @@ Describe 'Convert-HTMLToPDF' {
         New-Item -Path $PSScriptRoot -Force -ItemType Directory -Name 'Output' | Out-Null
     }
 
-    It 'converts HTML string to PDF' {
+    It 'converts HTML string to PDF and outputs file path' {
         $file = Join-Path $PSScriptRoot 'Output' 'converted.pdf'
-        Convert-HTMLToPDF -Content '<html><body>Test</body></html>' -OutputFilePath $file
+        $result = Convert-HTMLToPDF -Content '<html><body>Test</body></html>' -OutputFilePath $file
         Test-Path $file | Should -BeTrue
+        $result | Should -Be $file
+    }
+
+    It 'overwrites existing file only when Force is used' {
+        $file = Join-Path $PSScriptRoot 'Output' 'force.pdf'
+        Convert-HTMLToPDF -Content '<html><body>First</body></html>' -OutputFilePath $file | Out-Null
+        $timestamp = (Get-Item $file).LastWriteTime
+        Start-Sleep -Seconds 1
+        Convert-HTMLToPDF -Content '<html><body>Second</body></html>' -OutputFilePath $file | Out-Null
+        (Get-Item $file).LastWriteTime | Should -Be $timestamp
+        Convert-HTMLToPDF -Content '<html><body>Second</body></html>' -OutputFilePath $file -Force | Out-Null
+        (Get-Item $file).LastWriteTime | Should -Not -Be $timestamp
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary
- add ShouldProcess support and `-Force` switch to `Convert-HTMLToPDF`
- output created PDF path to the pipeline
- update examples and tests for new `-Force` behavior

## Testing
- `dotnet build Sources/PSWritePDF.sln`
- `pwsh -NoLogo -NoProfile -File ./PSWritePDF.Tests.ps1` *(fails: Could not find a part of the path '/workspace/PSWritePDF/Tests/Output/PDF4.pdf')*

------
https://chatgpt.com/codex/tasks/task_e_68932f8b466c832e951ada11e8d1ebe4