### PR TITLE
Enable piping file paths to Convert-PDFToText cmdlet

### DIFF
--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
@@ -12,8 +12,9 @@ namespace PSWritePDF.Cmdlets;
 [OutputType(typeof(string))]
 public class CmdletConvertPDFToText : PSCmdlet
 {
-    [Parameter(Mandatory = true)]
-    public string FilePath { get; set; }
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    [Alias("FullName")]
+    public string FilePath { get; set; } = string.Empty;
 
     [Parameter]
     public int[] Page { get; set; } = Array.Empty<int>();

--- a/Tests/Convert-PDFToText.Tests.ps1
+++ b/Tests/Convert-PDFToText.Tests.ps1
@@ -4,4 +4,9 @@ Describe 'Convert-PDFToText' {
         $text = Convert-PDFToText -FilePath $file
         ($text -join "`n") | Should -Match 'Text 1'
     }
+    It 'accepts piped Get-ChildItem results' {
+        $files = Get-ChildItem -Path (Join-Path $PSScriptRoot 'Input') -Filter '*.pdf'
+        $text = $files | Convert-PDFToText
+        ($text -join "`n") | Should -Match 'Text 1'
+    }
 }


### PR DESCRIPTION
## Summary
- allow `Convert-PDFToText` to receive `FilePath` from the pipeline
- test `Convert-PDFToText` using piped `Get-ChildItem` output

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pwsh -NoProfile -File PSWritePDF.Tests.ps1` *(fails: Importing module PSWritePDF failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac3a6340832ea845361366cf5034