### PR TITLE
Async HTTP support for Convert-HTMLToPDF cmdlet

### DIFF
--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
@@ -2,11 +2,12 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace PSWritePDF.Cmdlets;
 
 [Cmdlet(VerbsData.Convert, "HTMLToPDF", DefaultParameterSetName = ParameterSetNames.Uri, SupportsShouldProcess = true)]
-public class CmdletConvertHTMLToPDF : PSCmdlet
+public class CmdletConvertHTMLToPDF : AsyncPSCmdlet
 {
     private static class ParameterSetNames
     {
@@ -33,7 +34,7 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
     [Parameter]
     public SwitchParameter Force { get; set; }
 
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         string html = Content;
 
@@ -51,7 +52,7 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
             try
             {
                 using var client = new HttpClient();
-                html = client.GetStringAsync(Uri).GetAwaiter().GetResult();
+                html = await client.GetStringAsync(Uri).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -90,7 +91,10 @@ public class CmdletConvertHTMLToPDF : PSCmdlet
                 System.Diagnostics.Process.Start(psi);
             }
 
-            WriteObject(OutputFilePath);
+            if (ShouldProcess(OutputFilePath, "Write output"))
+            {
+                WriteObject(OutputFilePath);
+            }
         }
         catch (Exception ex)
         {

--- a/Tests/Convert-HTMLToPDF.Tests.ps1
+++ b/Tests/Convert-HTMLToPDF.Tests.ps1
@@ -1,6 +1,10 @@
 Describe 'Convert-HTMLToPDF' {
     BeforeAll {
-        New-Item -Path $PSScriptRoot -Force -ItemType Directory -Name 'Output' | Out-Null
+        $outputDir = Join-Path $PSScriptRoot 'Output'
+        if (Test-Path $outputDir) {
+            Remove-Item -LiteralPath $outputDir -Recurse -Force
+        }
+        New-Item -Path $outputDir -ItemType Directory | Out-Null
     }
 
     It 'converts HTML string to PDF and outputs file path' {
@@ -19,6 +23,13 @@ Describe 'Convert-HTMLToPDF' {
         (Get-Item $file).LastWriteTime | Should -Be $timestamp
         Convert-HTMLToPDF -Content '<html><body>Second</body></html>' -OutputFilePath $file -Force | Out-Null
         (Get-Item $file).LastWriteTime | Should -Not -Be $timestamp
+    }
+
+    It 'converts HTML from a URI' {
+        $file = Join-Path $PSScriptRoot 'Output' 'uri.pdf'
+        $result = Convert-HTMLToPDF -Uri 'https://example.com/' -OutputFilePath $file -Confirm:$false
+        Test-Path $file | Should -BeTrue
+        $result | Should -Be $file
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary
- derive `Convert-HTMLToPDF` from `AsyncPSCmdlet`
- fetch HTML with `HttpClient` asynchronously and guard output with `ShouldProcess`
- add URI-based conversion test

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -File ./PSWritePDF.Tests.ps1` *(fails: 11 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac7091d8832e9a052059b53f8d53