### PR TITLE
Add ShouldProcess and Force support to Split-PDF

### DIFF
--- a/Example/Example02.Splitting/Example02.ps1
+++ b/Example/Example02.Splitting/Example02.ps1
@@ -9,3 +9,9 @@ Split-PDF -FilePath "$PSScriptRoot\SampleToSplit.pdf" -OutputFolder "$PSScriptRo
 # Split PDF using bookmark titles
 Split-PDF -FilePath "$PSScriptRoot\SampleToSplit.pdf" -OutputFolder "$PSScriptRoot\Output" -Bookmark 'Chapter 1','Chapter 2'
 
+# Show a dry run without creating files
+Split-PDF -FilePath "$PSScriptRoot\SampleToSplit.pdf" -OutputFolder "$PSScriptRoot\Output" -SplitCount 1 -WhatIf
+
+# Overwrite existing files if needed
+Split-PDF -FilePath "$PSScriptRoot\SampleToSplit.pdf" -OutputFolder "$PSScriptRoot\Output" -SplitCount 1 -OutputName 'part' -Force
+

--- a/Sources/PSWritePDF/Support/PdfSequentialSplitter.cs
+++ b/Sources/PSWritePDF/Support/PdfSequentialSplitter.cs
@@ -10,19 +10,33 @@ internal sealed class PdfSequentialSplitter : PdfSplitter
 {
     private readonly string _destinationFolder;
     private readonly string _outputName;
+    private readonly bool _overwrite;
     private int _order;
+    public IList<string> OutputFiles { get; }
 
-    public PdfSequentialSplitter(PdfDocument pdfDocument, string destinationFolder, string outputName) : base(pdfDocument)
+    public PdfSequentialSplitter(PdfDocument pdfDocument, string destinationFolder, string outputName, bool overwrite) : base(pdfDocument)
     {
         _destinationFolder = destinationFolder;
         _outputName = outputName;
+        _overwrite = overwrite;
         _order = 0;
+        OutputFiles = new List<string>();
     }
 
     protected override PdfWriter GetNextPdfWriter(PageRange documentPageRange)
     {
         var name = $"{_outputName}{_order++}.pdf";
         var path = Path.Combine(_destinationFolder, name);
+        if (File.Exists(path))
+        {
+            if (!_overwrite)
+            {
+                throw new IOException($"File '{path}' already exists. Use -Force to overwrite.");
+            }
+            File.Delete(path);
+        }
+
+        OutputFiles.Add(path);
         return new PdfWriter(path);
     }
 

--- a/Tests/Split-PDF.Tests.ps1
+++ b/Tests/Split-PDF.Tests.ps1
@@ -22,24 +22,47 @@ Describe 'Split-PDF' {
         $output = Join-Path $PSScriptRoot 'Output' 'Parts'
         New-Item -Path $output -Force -ItemType Directory | Out-Null
         $file = Join-Path $PSScriptRoot 'Input' 'SampleToSplit.pdf'
-        Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -OutputName 'part'
-        (Get-ChildItem -Path $output -Filter 'part*.pdf').Count | Should -BeGreaterThan 1
+        $files = Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -OutputName 'part'
+        $files.Count | Should -BeGreaterThan 1
+        $files | ForEach-Object { Test-Path $_ | Should -BeTrue }
     }
 
     It 'splits pdf by page ranges' {
         $output = Join-Path $PSScriptRoot 'Output' 'Ranges'
         New-Item -Path $output -Force -ItemType Directory | Out-Null
         $file = Join-Path $PSScriptRoot 'Input' 'SampleToSplit.pdf'
-        Split-PDF -FilePath $file -OutputFolder $output -PageRange '1'
-        (Get-ChildItem -Path $output -Filter 'OutputDocument*.pdf').Count | Should -Be 1
+        $files = Split-PDF -FilePath $file -OutputFolder $output -PageRange '1'
+        $files.Count | Should -Be 1
+        $files | ForEach-Object { Test-Path $_ | Should -BeTrue }
     }
 
     It 'splits pdf by bookmarks' {
         $output = Join-Path $PSScriptRoot 'Output' 'Bookmarks'
         New-Item -Path $output -Force -ItemType Directory | Out-Null
         $file = Join-Path $PSScriptRoot 'Input' 'Bookmarked.pdf'
-        Split-PDF -FilePath $file -OutputFolder $output -Bookmark 'Chapter 1','Chapter 2'
-        (Get-ChildItem -Path $output -Filter 'OutputDocument*.pdf').Count | Should -Be 2
+        $files = Split-PDF -FilePath $file -OutputFolder $output -Bookmark 'Chapter 1','Chapter 2'
+        $files.Count | Should -Be 2
+        $files | ForEach-Object { Test-Path $_ | Should -BeTrue }
+    }
+
+    It 'performs a dry run with WhatIf' {
+        $output = Join-Path $PSScriptRoot 'Output' 'DryRun'
+        New-Item -Path $output -Force -ItemType Directory | Out-Null
+        $file = Join-Path $PSScriptRoot 'Input' 'SampleToSplit.pdf'
+        $files = Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -WhatIf
+        (Get-ChildItem -Path $output -Filter '*.pdf').Count | Should -Be 0
+        $files | Should -BeNullOrEmpty
+    }
+
+    It 'overwrites existing files with Force' {
+        $output = Join-Path $PSScriptRoot 'Output' 'Force'
+        New-Item -Path $output -Force -ItemType Directory | Out-Null
+        $file = Join-Path $PSScriptRoot 'Input' 'SampleToSplit.pdf'
+        $first = Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -OutputName 'part'
+        $second = Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -OutputName 'part'
+        $second | Should -BeNullOrEmpty
+        $forced = Split-PDF -FilePath $file -OutputFolder $output -SplitCount 1 -OutputName 'part' -Force
+        $forced.Count | Should -BeGreaterThan 0
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary
- add ShouldProcess/Force to `Split-PDF` and output resulting files
- track generated PDF paths in splitter implementation
- expand examples and tests for dry-run and overwrite scenarios

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` (failed: `[PSWritePDF/PSWritePDF.Tests.ps1]`)
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSWritePDF.psd1; Invoke-Pester -Script Tests/Split-PDF.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6894ac7d8b84832ea40f4045e940988d