### PR TITLE
Return objects from Convert-PDFToText and support saving output

### DIFF
--- a/Example/Example04.ExtractText/Example04.ps1
+++ b/Example/Example04.ExtractText/Example04.ps1
@@ -1,11 +1,16 @@
-﻿Import-Module .\PSWritePDF.psd1 -Force
+Import-Module .\PSWritePDF.psd1 -Force
 
-# Get all pages text
-Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf"
+# Get all pages text as objects
+$pages = Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf"
+$pages | Format-Table -AutoSize
 
+# Save combined text to file
+Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf" -OutFile "$PSScriptRoot\Example04.txt"
+
+# Use different extraction strategies
 Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf" -ExtractionStrategy LocationTextExtractionStrategy
-
 Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf" -ExtractionStrategy SimpleTextExtractionStrategy
 
 # Get page 1 text only
 Convert-PDFToText -FilePath "$PSScriptRoot\Example04.pdf" -Page 1 -IgnoreProtection
+

--- a/Tests/Convert-PDFToText.Tests.ps1
+++ b/Tests/Convert-PDFToText.Tests.ps1
@@ -1,12 +1,22 @@
 Describe 'Convert-PDFToText' {
-    It 'extracts text from PDF' {
+    It 'returns objects with PageNumber and Text' {
         $file = Join-Path $PSScriptRoot 'Input' 'SampleAcroForm.pdf'
         $text = Convert-PDFToText -FilePath $file
-        ($text -join "`n") | Should -Match 'Text 1'
+        $text | Should -AllBeOfType [pscustomobject]
+        $text[0].PageNumber | Should -Be 1
+        $text[0].Text | Should -Match 'Text 1'
     }
     It 'accepts piped Get-ChildItem results' {
         $files = Get-ChildItem -Path (Join-Path $PSScriptRoot 'Input') -Filter '*.pdf'
         $text = $files | Convert-PDFToText
-        ($text -join "`n") | Should -Match 'Text 1'
+        ($text | Select-Object -ExpandProperty Text | Out-String) | Should -Match 'Text 1'
+    }
+    It 'creates output file with combined text' {
+        $file = Join-Path $PSScriptRoot 'Input' 'SampleAcroForm.pdf'
+        $outFile = Join-Path $TestDrive 'output.txt'
+        $result = Convert-PDFToText -FilePath $file -OutFile $outFile
+        Test-Path $outFile | Should -BeTrue
+        ($result | Select-Object -ExpandProperty Text | Out-String) | Should -Match 'Text 1'
+        (Get-Content $outFile -Raw) | Should -Match 'Text 1'
     }
 }


### PR DESCRIPTION
## Summary
- return `[pscustomobject]` with PageNumber and Text from Convert-PDFToText
- add `-OutFile` switch to save combined text to disk
- test object schema and file creation for Convert-PDFToText

## Testing
- `dotnet build Sources/PSWritePDF.sln` *(fails: .NET SDK does not support targeting .NET 9.0)*
- `pwsh -NoLogo -NoProfile -File PSWritePDF.Tests.ps1` *(fails: Importing module PSWritePDF failed due to missing iText types)*

------
https://chatgpt.com/codex/tasks/task_e_6894eeeee404832ea7881b0b412919bc