### PR TITLE
Add PassThru for page and options cmdlets

### DIFF
--- a/Example/Example01.HelloWorld/Example01_MoreOptions.ps1
+++ b/Example/Example01.HelloWorld/Example01_MoreOptions.ps1
@@ -1,12 +1,13 @@
-﻿Import-Module .\PSWritePDF.psd1 -Force
+Import-Module .\PSWritePDF.psd1 -Force
 
-New-PDF  -MarginLeft 520 { #520 -MarginRight 20 -MarginTop 20 -MarginBottom 20 -PageSize B4 -Rotate {
+New-PDF -PageSize B4 -Rotate -FilePath "$PSScriptRoot\Example01_MoreOptions.pdf" -Show {
+    New-PDFOptions -MarginLeft 520 -MarginRight 20 -MarginTop 20 -MarginBottom 20 -PassThru | Out-Null
     New-PDFText -Text 'Test ', 'Me', 'Oooh' -FontColor BLUE, YELLOW, RED
     New-PDFList {
         New-PDFListItem -Text 'Test'
         New-PDFListItem -Text '2nd'
     }
-} -FilePath "$PSScriptRoot\Example01_MoreOptions.pdf" -Show
+}
 
 $Document = Get-PDF -FilePath "$PSScriptRoot\Example01_MoreOptions.pdf"
 $Details = Get-PDFDetails -Document $Document

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFOptions.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFOptions.cs
@@ -5,16 +5,35 @@ using PdfIMO;
 namespace PSWritePDF.Cmdlets;
 
 [Cmdlet(VerbsCommon.New, "PDFOptions")]
-public class CmdletNewPDFOptions : PSCmdlet {
+public class CmdletNewPDFOptions : PSCmdlet
+{
     [Parameter] public double? MarginLeft { get; set; }
     [Parameter] public double? MarginRight { get; set; }
     [Parameter] public double? MarginTop { get; set; }
     [Parameter] public double? MarginBottom { get; set; }
+    [Parameter] public SwitchParameter PassThru { get; set; }
 
-    protected override void ProcessRecord() {
+    protected override void ProcessRecord()
+    {
         var document = SessionState.PSVariable.GetValue("Document") as Document;
-        if (document != null) {
+        if (document != null)
+        {
             PdfOptions.Apply(document, (float?)MarginLeft, (float?)MarginRight, (float?)MarginTop, (float?)MarginBottom);
+            if (PassThru)
+            {
+                WriteObject(document);
+            }
+        }
+        else if (PassThru)
+        {
+            var options = new PdfDocumentOptions
+            {
+                MarginLeft = (float?)MarginLeft,
+                MarginRight = (float?)MarginRight,
+                MarginTop = (float?)MarginTop,
+                MarginBottom = (float?)MarginBottom
+            };
+            WriteObject(options);
         }
     }
 }

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFPage.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFPage.cs
@@ -16,6 +16,7 @@ public class CmdletNewPDFPage : PSCmdlet {
     [Parameter] public double? MarginBottom { get; set; }
     [Parameter] public PdfPageSize? PageSize { get; set; }
     [Parameter] public SwitchParameter Rotate { get; set; }
+    [Parameter] public SwitchParameter PassThru { get; set; }
 
     protected override void ProcessRecord() {
         var pdfDocument = SessionState.PSVariable.GetValue("PdfDocument") as iTextPdf.PdfDocument;
@@ -26,5 +27,9 @@ public class CmdletNewPDFPage : PSCmdlet {
         var document = PdfPage.AddPage(pdfDocument, size, Rotate.IsPresent, (float?)MarginLeft, (float?)MarginRight, (float?)MarginTop, (float?)MarginBottom);
         SessionState.PSVariable.Set("Document", document);
         PageContent?.Invoke();
+        if (PassThru)
+        {
+            WriteObject(document);
+        }
     }
 }

--- a/Sources/PSWritePDF/Support/PdfDocumentOptions.cs
+++ b/Sources/PSWritePDF/Support/PdfDocumentOptions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PSWritePDF;
+
+public class PdfDocumentOptions
+{
+    public float? MarginLeft { get; set; }
+    public float? MarginRight { get; set; }
+    public float? MarginTop { get; set; }
+    public float? MarginBottom { get; set; }
+}

--- a/Tests/AdditionalCmdlets.Tests.ps1
+++ b/Tests/AdditionalCmdlets.Tests.ps1
@@ -38,4 +38,28 @@ Describe 'Additional cmdlets' {
         $default = Get-Variable -Name DefaultFont -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Value
         $default | Should -Not -BeNullOrEmpty
     }
+
+    It 'New-PDFPage -PassThru returns document' {
+        $file = Join-Path $PSScriptRoot 'Output' 'page.pdf'
+        New-PDF -FilePath $file {
+            $doc = New-PDFPage -PassThru {
+                New-PDFText -Text 'Hi'
+            }
+            $doc | Should -BeOfType 'iText.Layout.Document'
+        }
+    }
+
+    It 'New-PDFOptions -PassThru returns document when available' {
+        $file = Join-Path $PSScriptRoot 'Output' 'optionsdoc.pdf'
+        New-PDF -FilePath $file {
+            $doc = New-PDFOptions -MarginLeft 15 -PassThru
+            $doc | Should -BeOfType 'iText.Layout.Document'
+        }
+    }
+
+    It 'New-PDFOptions -PassThru returns options object when document missing' {
+        $options = New-PDFOptions -MarginLeft 10 -PassThru
+        $options | Should -BeOfType 'PSWritePDF.PdfDocumentOptions'
+        $options.MarginLeft | Should -Be 10
+    }
 }


### PR DESCRIPTION
## Summary
- emit document or options object from `New-PDFOptions`
- add `-PassThru` to `New-PDFPage`
- demonstrate usage in example and tests

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj`
- `pwsh -NoLogo -Command "Invoke-Pester -Output Detailed"` *(fails: Tests Passed: 26, Failed: 11)*

------
https://chatgpt.com/codex/tasks/task_e_6894ef0cff1c832ea7e9c9717940332e