### PR TITLE
Add XML documentation for cmdlets and enable strict help generation

### DIFF
--- a/Sources/PSWritePDF/Cmdlets/CmdletClosePDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletClosePDF.cs
@@ -3,9 +3,34 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Closes an open PDF document.</summary>
+/// <para>Disposes the <c>PdfDocument</c> instance and releases associated resources.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>After closing, the document cannot be used further.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Close a document.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Close-PDF -Document $pdf
+/// </code>
+/// <para>Closes the specified PDF document.</para>
+/// </example>
+/// <example>
+/// <summary>Pipe a document.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>$pdf | Close-PDF
+/// </code>
+/// <para>Closes the document passed through the pipeline.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet("Close", "PDF")]
 public class CmdletClosePDF : PSCmdlet
 {
+    /// <summary>PDF document to close.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     public PdfDocument Document { get; set; } = null!;
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
@@ -8,6 +8,30 @@ using System.Threading.Tasks;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Converts HTML content to a PDF file.</summary>
+/// <para>Accepts HTML from a URI, string content, or file and writes a PDF to disk.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Existing output files are overwritten when <c>-Force</c> is specified.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Convert from URI.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Convert-HTMLToPDF -Uri 'https://example.com' -OutputFilePath 'page.pdf'
+/// </code>
+/// <para>Downloads the page and saves it as PDF.</para>
+/// </example>
+/// <example>
+/// <summary>Convert from file with CSS.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Convert-HTMLToPDF -FilePath 'index.html' -CssFilePath 'style.css' -OutputFilePath 'out.pdf'
+/// </code>
+/// <para>Applies the specified CSS and writes the PDF.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsData.Convert, "HTMLToPDF", DefaultParameterSetName = ParameterSetNames.Uri, SupportsShouldProcess = true)]
 public class CmdletConvertHTMLToPDF : AsyncPSCmdlet
 {
@@ -18,27 +42,35 @@ public class CmdletConvertHTMLToPDF : AsyncPSCmdlet
         public const string File = "File";
     }
 
+    /// <summary>URI of the HTML page.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.Uri)]
     public string Uri { get; set; }
 
+    /// <summary>Raw HTML content.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.Content)]
     public string Content { get; set; }
 
+    /// <summary>Path to an HTML file.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.File)]
     public string FilePath { get; set; }
 
+    /// <summary>Output PDF path.</summary>
     [Parameter(Mandatory = true)]
     public string OutputFilePath { get; set; }
 
+    /// <summary>Open the PDF after creation.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
 
+    /// <summary>Overwrite existing files.</summary>
     [Parameter]
     public SwitchParameter Force { get; set; }
 
+    /// <summary>Base URI for relative links.</summary>
     [Parameter]
     public string BaseUri { get; set; }
 
+    /// <summary>Paths to CSS files to include.</summary>
     [Parameter]
     public string[] CssFilePath { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
@@ -9,23 +9,52 @@ using iText.Kernel.Pdf.Canvas.Parser;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Converts PDF pages to plain text.</summary>
+/// <para>Extracts text from specified pages of a PDF document using iText strategies.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Protected documents may require the <c>IgnoreProtection</c> switch to extract text.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Extract text from a PDF.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Convert-PDFToText -FilePath 'file.pdf'
+/// </code>
+/// <para>Returns text objects for each page.</para>
+/// </example>
+/// <example>
+/// <summary>Save extracted text to a file.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Convert-PDFToText -FilePath 'file.pdf' -OutFile 'output.txt'
+/// </code>
+/// <para>Writes combined text to the specified file.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsData.Convert, "PDFToText")]
 [OutputType(typeof(PSObject))]
 public class CmdletConvertPDFToText : PSCmdlet
 {
+    /// <summary>Path to the PDF file.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     [Alias("FullName")]
     public string FilePath { get; set; } = string.Empty;
 
+    /// <summary>Pages to extract.</summary>
     [Parameter]
     public int[] Page { get; set; } = Array.Empty<int>();
 
+    /// <summary>Extraction strategy to use.</summary>
     [Parameter]
     public PdfExtractionStrategyName ExtractionStrategy { get; set; } = PdfExtractionStrategyName.Simple;
 
+    /// <summary>Ignore document protection.</summary>
     [Parameter]
     public SwitchParameter IgnoreProtection { get; set; }
 
+    /// <summary>Optional output file.</summary>
     [Parameter]
     public string? OutFile { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDF.cs
@@ -5,13 +5,39 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Opens an existing PDF file.</summary>
+/// <para>Returns an iText <c>PdfDocument</c> for further processing.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The caller must dispose the returned document.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Load a PDF.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDF -FilePath 'doc.pdf'
+/// </code>
+/// <para>Returns a <c>PdfDocument</c> instance.</para>
+/// </example>
+/// <example>
+/// <summary>Ignore protection.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDF -FilePath 'doc.pdf' -IgnoreProtection
+/// </code>
+/// <para>Opens a protected PDF for reading.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDF")]
 [OutputType(typeof(PdfDocument))]
 public class CmdletGetPDF : PSCmdlet
 {
+    /// <summary>Path to the PDF file.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     public string FilePath { get; set; } = null!;
 
+    /// <summary>Ignore document protection.</summary>
     [Parameter]
     public SwitchParameter IgnoreProtection { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDFAction.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDFAction.cs
@@ -4,6 +4,30 @@ using PSWritePDF;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Gets numeric values of PDF actions.</summary>
+/// <para>Converts <c>PdfActionName</c> values to their integer representation or lists all names.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Action names correspond to constants defined in iText.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get integer value for an action.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFAction -Action Hide
+/// </code>
+/// <para>Returns the numeric constant for the Hide action.</para>
+/// </example>
+/// <example>
+/// <summary>List all action names.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFAction -All
+/// </code>
+/// <para>Displays all available action names.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDFAction", DefaultParameterSetName = ParameterSetNames.ByName)]
 [Alias("Get-PDFConstantAction")]
 [OutputType(typeof(int), ParameterSetName = new[] { ParameterSetNames.ByName })]
@@ -16,9 +40,11 @@ public class CmdletGetPDFAction : PSCmdlet
         public const string All = "All";
     }
 
+    /// <summary>Action name to translate.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.ByName)]
     public PdfActionName Action { get; set; }
 
+    /// <summary>Return all action names.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.All)]
     public SwitchParameter All { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDFDetails.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDFDetails.cs
@@ -4,10 +4,35 @@ using iText.Layout;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Gets descriptive information about a PDF document.</summary>
+/// <para>Returns metadata, margins, page sizes, and other details.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The document is inspected but not modified.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Retrieve document details.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFDetails -Document $pdf
+/// </code>
+/// <para>Outputs a <c>PdfDocumentDetails</c> object.</para>
+/// </example>
+/// <example>
+/// <summary>Pipe from New-PDF.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDF -FilePath 'out.pdf' | Get-PDFDetails
+/// </code>
+/// <para>Creates a PDF and immediately inspects it.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDFDetails")]
 [OutputType(typeof(PdfDocumentDetails))]
 public class CmdletGetPDFDetails : PSCmdlet
 {
+    /// <summary>PDF document to analyze.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     public PdfDocument Document { get; set; } = null!;
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDFFormField.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDFFormField.cs
@@ -5,9 +5,34 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Retrieves form fields from a PDF document.</summary>
+/// <para>Enumerates AcroForm fields and returns their names and objects.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The cmdlet emits warnings if the document contains no forms.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>List form fields.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFFormField -PDF $pdf
+/// </code>
+/// <para>Outputs form field information.</para>
+/// </example>
+/// <example>
+/// <summary>Stop on read errors.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFFormField -PDF $pdf -ErrorAction Stop
+/// </code>
+/// <para>Throws a terminating error if forms cannot be read.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDFFormField")]
 public class CmdletGetPDFFormField : PSCmdlet
 {
+    /// <summary>PDF document to inspect.</summary>
     [Parameter(Mandatory = true)]
     public PdfDocument PDF { get; set; } = null!;
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDFPageSize.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDFPageSize.cs
@@ -4,6 +4,30 @@ using PSWritePDF;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Gets standard PDF page sizes.</summary>
+/// <para>Returns an iText <c>PageSize</c> or enumerates available page size names.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Page size names correspond to <c>PdfPageSizeName</c> enumeration values.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get size for A4.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFPageSize -PageSize A4
+/// </code>
+/// <para>Returns the iText page size for A4.</para>
+/// </example>
+/// <example>
+/// <summary>List all page sizes.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFPageSize -All
+/// </code>
+/// <para>Displays all supported page size names.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDFPageSize", DefaultParameterSetName = ParameterSetNames.ByName)]
 [Alias("Get-PDFConstantPageSize")]
 [OutputType(typeof(iText.Kernel.Geom.PageSize), ParameterSetName = new[] { ParameterSetNames.ByName })]
@@ -16,9 +40,11 @@ public class CmdletGetPDFPageSize : PSCmdlet
         public const string All = "All";
     }
 
+    /// <summary>Page size name to retrieve.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.ByName)]
     public PdfPageSizeName PageSize { get; set; }
 
+    /// <summary>Return all page size names.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.All)]
     public SwitchParameter All { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDFVersion.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDFVersion.cs
@@ -4,6 +4,30 @@ using PSWritePDF;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Retrieves PDF version information.</summary>
+/// <para>Returns a specific PDF version constant or lists all available versions.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Version names must match those defined by iText.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get a specific version.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFVersion -Version PDF_2_0
+/// </code>
+/// <para>Returns the iText version constant for PDF 2.0.</para>
+/// </example>
+/// <example>
+/// <summary>List all versions.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Get-PDFVersion -All
+/// </code>
+/// <para>Displays all supported PDF versions.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "PDFVersion", DefaultParameterSetName = ParameterSetNames.ByName)]
 [Alias("Get-PDFConstantVersion")]
 [OutputType(typeof(iText.Kernel.Pdf.PdfVersion), ParameterSetName = new[] { ParameterSetNames.ByName })]
@@ -16,9 +40,11 @@ public class CmdletGetPDFVersion : PSCmdlet
         public const string All = "All";
     }
 
+    /// <summary>Version name to translate.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.ByName)]
     public PdfVersionName Version { get; set; }
 
+    /// <summary>Return all version names.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.All)]
     public SwitchParameter All { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletMergePDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletMergePDF.cs
@@ -6,15 +6,42 @@ using iText.Kernel.Utils;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Merges multiple PDF files into one.</summary>
+/// <para>Combines input PDFs in order and saves the result to a specified file.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Existing output files are overwritten without prompt.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Merge two files.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Merge-PDF -InputFile 'a.pdf','b.pdf' -OutputFile 'merged.pdf'
+/// </code>
+/// <para>Creates a single PDF containing pages from both inputs.</para>
+/// </example>
+/// <example>
+/// <summary>Merge ignoring protection.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Merge-PDF -InputFile $files -OutputFile 'all.pdf' -IgnoreProtection
+/// </code>
+/// <para>Processes protected files as well.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsData.Merge, "PDF")]
 public class CmdletMergePDF : PSCmdlet
 {
+    /// <summary>Paths to PDF files to merge.</summary>
     [Parameter(Mandatory = true)]
     public string[] InputFile { get; set; }
 
+    /// <summary>Path for the merged output.</summary>
     [Parameter(Mandatory = true)]
     public string OutputFile { get; set; }
 
+    /// <summary>Ignore protection on input files.</summary>
     [Parameter]
     public SwitchParameter IgnoreProtection { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDF.cs
@@ -8,23 +8,57 @@ using iTextPdf = iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Creates a new PDF document.</summary>
+/// <para>Builds a PDF file and optionally executes script block content to populate the document.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Existing files at the target path are overwritten without confirmation.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create an empty PDF file.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDF -FilePath 'out.pdf'
+/// </code>
+/// <para>Generates a PDF at the specified path.</para>
+/// </example>
+/// <example>
+/// <summary>Create and display a PDF.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDF -FilePath 'out.pdf' -Show
+/// </code>
+/// <para>The created PDF opens in the default viewer.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDF")]
 public class CmdletNewPDF : PSCmdlet {
+    /// <summary>Script block defining PDF content.</summary>
     [Parameter(Position = 0)]
     public ScriptBlock? PDFContent { get; set; }
 
+    /// <summary>Output file path.</summary>
     [Parameter(Mandatory = true)]
     public string FilePath { get; set; } = string.Empty;
 
+    /// <summary>PDF version to use.</summary>
     [Parameter]
     public string? Version { get; set; }
 
+    /// <summary>Left margin in points.</summary>
     [Parameter] public double? MarginLeft { get; set; }
+    /// <summary>Right margin in points.</summary>
     [Parameter] public double? MarginRight { get; set; }
+    /// <summary>Top margin in points.</summary>
     [Parameter] public double? MarginTop { get; set; }
+    /// <summary>Bottom margin in points.</summary>
     [Parameter] public double? MarginBottom { get; set; }
+    /// <summary>Initial page size.</summary>
     [Parameter] public PdfPageSize? PageSize { get; set; }
+    /// <summary>Rotate the page 90 degrees.</summary>
     [Parameter] public SwitchParameter Rotate { get; set; }
+    /// <summary>Show the PDF after creation.</summary>
     [Parameter, Alias("Open")] public SwitchParameter Show { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFArea.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFArea.cs
@@ -4,15 +4,42 @@ using iText.Layout.Properties;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Creates a new area break for PDF content.</summary>
+/// <para>Generates an iText <c>AreaBreak</c> object used to separate sections in a PDF document.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The returned area break must be added to a PDF document to take effect.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create a default area break.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFArea
+/// </code>
+/// <para>Creates a break with default settings.</para>
+/// </example>
+/// <example>
+/// <summary>Create a rotated A4 area break.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFArea -PageSize A4 -Rotate
+/// </code>
+/// <para>Produces a break on a landscape A4 page.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFArea")]
 public class CmdletNewPDFArea : PSCmdlet
 {
+    /// <summary>Type of area break to insert.</summary>
     [Parameter]
     public AreaBreakType AreaType { get; set; } = AreaBreakType.NEXT_AREA;
 
+    /// <summary>Page size for the new area.</summary>
     [Parameter]
     public PdfPageSizeName? PageSize { get; set; }
 
+    /// <summary>Rotate the page to landscape.</summary>
     [Parameter]
     public SwitchParameter Rotate { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFDocument.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFDocument.cs
@@ -4,9 +4,34 @@ using iText.Layout;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Wraps a PDF document in an iText <c>Document</c>.</summary>
+/// <para>Creates a layout <c>Document</c> object for further content operations.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The caller is responsible for closing the document.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create a document object.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFDocument -PDF $pdf
+/// </code>
+/// <para>Returns an iText layout document.</para>
+/// </example>
+/// <example>
+/// <summary>Store document for later use.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>$doc = New-PDFDocument -PDF $pdf
+/// </code>
+/// <para>Assigns the document to a variable.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFDocument")]
 public class CmdletNewPDFDocument : PSCmdlet
 {
+    /// <summary>Underlying PDF document.</summary>
     [Parameter(Mandatory = true)]
     public PdfDocument PDF { get; set; } = null!;
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
@@ -5,13 +5,42 @@ using PdfIMO;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Adds an image to the current PDF document.</summary>
+/// <para>Loads an image from disk and inserts it with optional size and background color.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Image files must exist; missing files cause a terminating error.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Add an image.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFImage -ImagePath 'logo.png'
+/// </code>
+/// <para>Inserts the image using its original dimensions.</para>
+/// </example>
+/// <example>
+/// <summary>Add image with size.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFImage -ImagePath 'logo.png' -Width 100 -Height 50
+/// </code>
+/// <para>Scales the image to the specified size.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFImage")]
 public class CmdletNewPDFImage : PSCmdlet {
+    /// <summary>Path to the image file.</summary>
     [Parameter(Mandatory = true)]
     public string ImagePath { get; set; } = string.Empty;
+    /// <summary>Desired image width.</summary>
     [Parameter] public int Width { get; set; }
+    /// <summary>Desired image height.</summary>
     [Parameter] public int Height { get; set; }
+    /// <summary>Background color behind the image.</summary>
     [Parameter] public PdfColor? BackgroundColor { get; set; }
+    /// <summary>Opacity of the background color.</summary>
     [Parameter] public double? BackgroundColorOpacity { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFInfo.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFInfo.cs
@@ -4,18 +4,50 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Applies metadata to a PDF document.</summary>
+/// <para>Sets title, author, keywords, and optional creation/modification dates.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Changes affect the in-memory document and require saving to persist.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Add basic metadata.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFInfo -PDF $pdf -Title 'Report'
+/// </code>
+/// <para>Sets the document title.</para>
+/// </example>
+/// <example>
+/// <summary>Add creation date.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFInfo -PDF $pdf -AddCreationDate
+/// </code>
+/// <para>Stores the current time as the creation date.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFInfo")]
 public class CmdletNewPDFInfo : PSCmdlet
 {
+    /// <summary>PDF document to modify.</summary>
     [Parameter(Mandatory = true)]
     public PdfDocument PDF { get; set; } = null!;
 
+    /// <summary>Document title.</summary>
     [Parameter] public string? Title { get; set; }
+    /// <summary>Document author.</summary>
     [Parameter] public string? Author { get; set; }
+    /// <summary>Document creator.</summary>
     [Parameter] public string? Creator { get; set; }
+    /// <summary>Document subject.</summary>
     [Parameter] public string? Subject { get; set; }
+    /// <summary>Keywords to add.</summary>
     [Parameter] public string[]? Keywords { get; set; }
+    /// <summary>Add creation date metadata.</summary>
     [Parameter] public SwitchParameter AddCreationDate { get; set; }
+    /// <summary>Add modification date metadata.</summary>
     [Parameter] public SwitchParameter AddModificationDate { get; set; }
 
     protected override void ProcessRecord()

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFList.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFList.cs
@@ -6,21 +6,57 @@ using PdfIMO;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Adds a list of items to the current PDF document.</summary>
+/// <para>Creates a bullet or numbered list using provided items or a script block.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The list is only added if a document is available in the session.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create a list from strings.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFList -Items 'one','two'
+/// </code>
+/// <para>Adds a simple bullet list.</para>
+/// </example>
+/// <example>
+/// <summary>Generate list via script block.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFList -ListItems { 1..3 }
+/// </code>
+/// <para>Creates a list using numbers returned from the script block.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFList")]
 public class CmdletNewPDFList : PSCmdlet {
+    /// <summary>Script block producing list items.</summary>
     [Parameter(Position = 0, ParameterSetName = "ScriptBlock")]
     public ScriptBlock? ListItems { get; set; }
+    /// <summary>Items to include in the list.</summary>
     [Parameter(Position = 0, ParameterSetName = "Items")]
     public string[]? Items { get; set; }
+    /// <summary>List indentation in points.</summary>
     [Parameter] public double? Indent { get; set; }
+    /// <summary>Symbol style for the list.</summary>
     [Parameter] public ListSymbol Symbol { get; set; } = ListSymbol.Hyphen;
+    /// <summary>Font for list items.</summary>
     [Parameter] public PdfFontName? Font { get; set; }
+    /// <summary>Color of the font.</summary>
     [Parameter] public PdfColor? FontColor { get; set; }
+    /// <summary>Font size.</summary>
     [Parameter] public int? FontSize { get; set; }
+    /// <summary>Text alignment of the list.</summary>
     [Parameter] public TextAlignment? TextAlignment { get; set; }
+    /// <summary>Top margin.</summary>
     [Parameter] public double? MarginTop { get; set; }
+    /// <summary>Bottom margin.</summary>
     [Parameter] public double? MarginBottom { get; set; }
+    /// <summary>Left margin.</summary>
     [Parameter] public double? MarginLeft { get; set; }
+    /// <summary>Right margin.</summary>
     [Parameter] public double? MarginRight { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFListItem.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFListItem.cs
@@ -2,8 +2,33 @@ using System.Management.Automation;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Creates a list item string.</summary>
+/// <para>Outputs the provided text for use with <c>New-PDFList</c>.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>This cmdlet simply echoes the text as a list item.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create an item.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFListItem -Text 'First'
+/// </code>
+/// <para>Returns the string 'First'.</para>
+/// </example>
+/// <example>
+/// <summary>Use with a list.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFList -ListItems { New-PDFListItem -Text 'A' }
+/// </code>
+/// <para>Creates a list containing one item.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFListItem")]
 public class CmdletNewPDFListItem : PSCmdlet {
+    /// <summary>Text for the list item.</summary>
     [Parameter(Mandatory = true)]
     public string Text { get; set; } = string.Empty;
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFOptions.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFOptions.cs
@@ -4,13 +4,42 @@ using PdfIMO;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Creates or applies PDF margin options.</summary>
+/// <para>Modifies margins of the current document or returns an options object.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>No changes are made if no document is open.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Set margins on active document.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFOptions -MarginTop 20 -MarginBottom 20
+/// </code>
+/// <para>Applies new margins to the current document.</para>
+/// </example>
+/// <example>
+/// <summary>Return options object.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>$opts = New-PDFOptions -MarginLeft 10 -MarginRight 10 -PassThru
+/// </code>
+/// <para>Creates a <c>PdfDocumentOptions</c> instance for later use.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFOptions")]
 public class CmdletNewPDFOptions : PSCmdlet
 {
+    /// <summary>Left margin in points.</summary>
     [Parameter] public double? MarginLeft { get; set; }
+    /// <summary>Right margin in points.</summary>
     [Parameter] public double? MarginRight { get; set; }
+    /// <summary>Top margin in points.</summary>
     [Parameter] public double? MarginTop { get; set; }
+    /// <summary>Bottom margin in points.</summary>
     [Parameter] public double? MarginBottom { get; set; }
+    /// <summary>Return the updated document or options.</summary>
     [Parameter] public SwitchParameter PassThru { get; set; }
 
     protected override void ProcessRecord()

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFPage.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFPage.cs
@@ -5,17 +5,49 @@ using iTextPdf = iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Adds a new page to the active PDF document.</summary>
+/// <para>Creates a page with optional margins and size, executing a script block for content if supplied.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>This cmdlet requires a document created by <c>New-PDF</c>.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Add a blank page.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFPage
+/// </code>
+/// <para>Creates a default page.</para>
+/// </example>
+/// <example>
+/// <summary>Add content to a page.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFPage -PageContent { New-PDFText -Text 'Hello' }
+/// </code>
+/// <para>Inserts a page and writes text on it.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFPage")]
 public class CmdletNewPDFPage : PSCmdlet {
+    /// <summary>Script block defining page content.</summary>
     [Parameter(Position = 0)]
     public ScriptBlock? PageContent { get; set; }
 
+    /// <summary>Left margin in points.</summary>
     [Parameter] public double? MarginLeft { get; set; }
+    /// <summary>Right margin in points.</summary>
     [Parameter] public double? MarginRight { get; set; }
+    /// <summary>Top margin in points.</summary>
     [Parameter] public double? MarginTop { get; set; }
+    /// <summary>Bottom margin in points.</summary>
     [Parameter] public double? MarginBottom { get; set; }
+    /// <summary>Page size to apply.</summary>
     [Parameter] public PdfPageSize? PageSize { get; set; }
+    /// <summary>Rotate the page orientation.</summary>
     [Parameter] public SwitchParameter Rotate { get; set; }
+    /// <summary>Emit the <c>Document</c> object.</summary>
     [Parameter] public SwitchParameter PassThru { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFTable.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFTable.cs
@@ -7,8 +7,33 @@ using PdfIMO;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Creates a table in the current PDF document.</summary>
+/// <para>Builds an iText <c>Table</c> from PowerShell objects and adds it to the active document.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The table is added only when a document is stored in the session.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Add a table from objects.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFTable -DataTable $objects
+/// </code>
+/// <para>Creates a table using property names as columns.</para>
+/// </example>
+/// <example>
+/// <summary>Create an empty table.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFTable
+/// </code>
+/// <para>Outputs a table object without adding rows.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFTable")]
 public class CmdletNewPDFTable : PSCmdlet {
+    /// <summary>Objects representing table rows.</summary>
     [Parameter]
     public PSObject[] DataTable { get; set; } = Array.Empty<PSObject>();
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFText.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFText.cs
@@ -7,19 +7,53 @@ using PdfIMO;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Adds a paragraph of text to the current PDF document.</summary>
+/// <para>Creates an iText <c>Paragraph</c> with formatting options and writes it to the active document.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The paragraph is added only if a document is stored in the <c>Document</c> session variable.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Add basic text.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFText -Text 'Hello World'
+/// </code>
+/// <para>Inserts a paragraph with the specified text.</para>
+/// </example>
+/// <example>
+/// <summary>Use custom font and size.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>New-PDFText -Text 'Hello' -FontSize 18 -FontBold $true
+/// </code>
+/// <para>Creates emphasized text in the document.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "PDFText")]
 public class CmdletNewPDFText : PSCmdlet {
+    /// <summary>Text lines to add.</summary>
     [Parameter(Mandatory = true)]
     public string[] Text { get; set; } = Array.Empty<string>();
 
+    /// <summary>Fonts for each line.</summary>
     [Parameter] public PdfFontName[]? Font { get; set; }
+    /// <summary>Font colors.</summary>
     [Parameter] public PdfColor[]? FontColor { get; set; }
+    /// <summary>Apply bold style per line.</summary>
     [Parameter] public bool?[]? FontBold { get; set; }
+    /// <summary>Font size in points.</summary>
     [Parameter] public int? FontSize { get; set; }
+    /// <summary>Alignment of the text.</summary>
     [Parameter] public TextAlignment? TextAlignment { get; set; }
+    /// <summary>Top margin in points.</summary>
     [Parameter] public double? MarginTop { get; set; } = 2;
+    /// <summary>Bottom margin in points.</summary>
     [Parameter] public double? MarginBottom { get; set; } = 2;
+    /// <summary>Left margin in points.</summary>
     [Parameter] public double? MarginLeft { get; set; }
+    /// <summary>Right margin in points.</summary>
     [Parameter] public double? MarginRight { get; set; }
 
     protected override void ProcessRecord() {

--- a/Sources/PSWritePDF/Cmdlets/CmdletRegisterPDFFont.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletRegisterPDFFont.cs
@@ -7,24 +7,54 @@ using iText.Kernel.Font;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Registers a font for use in PDF generation.</summary>
+/// <para>Adds a font to the session cache and optionally sets it as default.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Font files must exist on disk; missing paths trigger warnings.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Register a font.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Register-PDFFont -FontName MyFont -FontPath 'c:\fonts\my.ttf'
+/// </code>
+/// <para>Makes the font available for later use.</para>
+/// </example>
+/// <example>
+/// <summary>Register and set as default.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Register-PDFFont -FontName MyFont -FontPath 'c:\fonts\my.ttf' -Default
+/// </code>
+/// <para>Subsequent text uses this font automatically.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Register, "PDFFont")]
 public class CmdletRegisterPDFFont : PSCmdlet
 {
+    /// <summary>Name used to reference the font.</summary>
     [Parameter(Mandatory = true)]
     public string FontName { get; set; } = string.Empty;
 
+    /// <summary>Path to the font file.</summary>
     [Parameter(Mandatory = true)]
     public string FontPath { get; set; } = string.Empty;
 
+    /// <summary>Optional encoding for the font.</summary>
     [Parameter]
     public PdfFontEncoding Encoding { get; set; } = PdfFontEncoding.None;
 
+    /// <summary>Embedding strategy for the font.</summary>
     [Parameter]
     public PdfFontFactory.EmbeddingStrategy EmbeddingStrategy { get; set; } = PdfFontFactory.EmbeddingStrategy.PREFER_EMBEDDED;
 
+    /// <summary>Cache the font for reuse.</summary>
     [Parameter]
     public SwitchParameter Cached { get; set; }
 
+    /// <summary>Set the font as default.</summary>
     [Parameter]
     public SwitchParameter Default { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletSetPDFForm.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletSetPDFForm.cs
@@ -8,27 +8,57 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Sets values of PDF form fields.</summary>
+/// <para>Copies an existing PDF, populates AcroForm fields, and optionally flattens them.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Source documents are read entirely and may require removal of protection for editing.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Populate form fields.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Set-PDFForm -SourceFilePath 'in.pdf' -DestinationFilePath 'out.pdf' -FieldNameAndValueHashTable $hash
+/// </code>
+/// <para>Copies the source PDF and sets fields as specified.</para>
+/// </example>
+/// <example>
+/// <summary>Flatten fields.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Set-PDFForm -SourceFilePath 'in.pdf' -DestinationFilePath 'out.pdf' -Flatten
+/// </code>
+/// <para>Writes a new PDF with non-editable fields.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Set, "PDFForm")]
 public class CmdletSetPDFForm : PSCmdlet
 {
+    /// <summary>Path to the source PDF with form fields.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string SourceFilePath { get; set; }
 
+    /// <summary>Destination path for the output PDF.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string DestinationFilePath { get; set; }
 
+    /// <summary>Hashtable of field names and values.</summary>
     [Parameter(ValueFromPipeline = true)]
     public IDictionary FieldNameAndValueHashTable { get; set; }
 
+    /// <summary>Flatten the fields to make them read-only.</summary>
     [Parameter]
     [Alias("FlattenFields")]
     public SwitchParameter Flatten { get; set; }
 
+    /// <summary>Ignore document protection when reading.</summary>
     [Parameter]
     public SwitchParameter IgnoreProtection { get; set; }
 
+    /// <summary>Return the destination file path.</summary>
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 

--- a/Sources/PSWritePDF/Cmdlets/CmdletSplitPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletSplitPDF.cs
@@ -6,6 +6,30 @@ using iText.Kernel.Pdf;
 
 namespace PSWritePDF.Cmdlets;
 
+/// <summary>Splits a PDF into multiple documents.</summary>
+/// <para>Supports splitting by page count, page ranges, or bookmarks.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Existing files in the destination may be overwritten when <c>Force</c> is specified.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Split by page count.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Split-PDF -FilePath 'in.pdf' -OutputFolder './out' -SplitCount 2
+/// </code>
+/// <para>Creates output files containing two pages each.</para>
+/// </example>
+/// <example>
+/// <summary>Split by page ranges.</summary>
+/// <code>
+/// <prefix>PS&gt; </prefix>Split-PDF -FilePath 'in.pdf' -OutputFolder './out' -PageRange '1-3','4-6'
+/// </code>
+/// <para>Produces files for the specified ranges.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/api/system.management.automation.cmdlet">MS Learn</seealso>
+/// <seealso href="https://evotec.xyz/hub/scripts/pswritepdf/">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Split, "PDF", SupportsShouldProcess = true)]
 public class CmdletSplitPDF : PSCmdlet
 {
@@ -13,35 +37,43 @@ public class CmdletSplitPDF : PSCmdlet
     private const string PageRangeParameterSet = "PageRange";
     private const string BookmarkParameterSet = "Bookmark";
 
+    /// <summary>Path to the source PDF.</summary>
     [Parameter(Mandatory = true, ParameterSetName = SplitCountParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = PageRangeParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = BookmarkParameterSet)]
     public string FilePath { get; set; }
 
+    /// <summary>Destination folder for split files.</summary>
     [Parameter(Mandatory = true, ParameterSetName = SplitCountParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = PageRangeParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = BookmarkParameterSet)]
     public string OutputFolder { get; set; }
 
+    /// <summary>Base name for output files.</summary>
     [Parameter(ParameterSetName = SplitCountParameterSet)]
     [Parameter(ParameterSetName = PageRangeParameterSet)]
     [Parameter(ParameterSetName = BookmarkParameterSet)]
     public string OutputName { get; set; } = "OutputDocument";
 
+    /// <summary>Number of pages per output file.</summary>
     [Parameter(ParameterSetName = SplitCountParameterSet)]
     public int SplitCount { get; set; } = 1;
 
+    /// <summary>Page ranges to extract.</summary>
     [Parameter(ParameterSetName = PageRangeParameterSet)]
     public string[] PageRange { get; set; }
 
+    /// <summary>Bookmark titles that define splits.</summary>
     [Parameter(ParameterSetName = BookmarkParameterSet)]
     public string[] Bookmark { get; set; }
 
+    /// <summary>Ignore document protection.</summary>
     [Parameter(ParameterSetName = SplitCountParameterSet)]
     [Parameter(ParameterSetName = PageRangeParameterSet)]
     [Parameter(ParameterSetName = BookmarkParameterSet)]
     public SwitchParameter IgnoreProtection { get; set; }
 
+    /// <summary>Overwrite existing files without prompting.</summary>
     [Parameter(ParameterSetName = SplitCountParameterSet)]
     [Parameter(ParameterSetName = PageRangeParameterSet)]
     [Parameter(ParameterSetName = BookmarkParameterSet)]

--- a/Sources/PSWritePDF/PSWritePDF.csproj
+++ b/Sources/PSWritePDF/PSWritePDF.csproj
@@ -44,6 +44,7 @@
     <PropertyGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
     </PropertyGroup>
 
 

--- a/Sources/PSWritePDF/Support/PdfActionName.cs
+++ b/Sources/PSWritePDF/Support/PdfActionName.cs
@@ -1,5 +1,6 @@
 namespace PSWritePDF;
 
+/// <summary>Specifies available PDF form action flags.</summary>
 public enum PdfActionName
 {
     RESET_EXCLUDE,

--- a/Sources/PSWritePDF/Support/PdfDetails.cs
+++ b/Sources/PSWritePDF/Support/PdfDetails.cs
@@ -1,5 +1,6 @@
 namespace PSWritePDF;
 
+/// <summary>Enumerates known PDF page size names.</summary>
 public enum PdfPageSizeName
 {
     A0,
@@ -31,31 +32,53 @@ public enum PdfPageSizeName
     Unknown
 }
 
+/// <summary>Represents detailed information about a PDF page.</summary>
 public class PdfPageDetails
 {
+    /// <summary>Height of the page in points.</summary>
     public int Height { get; set; }
+    /// <summary>Width of the page in points.</summary>
     public int Width { get; set; }
+    /// <summary>Rotation angle.</summary>
     public int Rotation { get; set; }
+    /// <summary>Named page size.</summary>
     public PdfPageSizeName Size { get; set; } = PdfPageSizeName.Unknown;
+    /// <summary>Indicates if the page is rotated.</summary>
     public bool? Rotated { get; set; }
 }
 
+/// <summary>Aggregated details for a PDF document.</summary>
 public class PdfDocumentDetails
 {
+    /// <summary>Document author.</summary>
     public string? Author { get; set; }
+    /// <summary>Document creator.</summary>
     public string? Creator { get; set; }
+    /// <summary>Internal hash code.</summary>
     public int HashCode { get; set; }
+    /// <summary>Document keywords.</summary>
     public string? Keywords { get; set; }
+    /// <summary>Document producer.</summary>
     public string? Producer { get; set; }
+    /// <summary>Document subject.</summary>
     public string? Subject { get; set; }
+    /// <summary>Document title.</summary>
     public string? Title { get; set; }
+    /// <summary>Trapping information.</summary>
     public string? Trapped { get; set; }
+    /// <summary>PDF version used.</summary>
     public iText.Kernel.Pdf.PdfVersion Version { get; set; }
+    /// <summary>Total number of pages.</summary>
     public int PagesNumber { get; set; }
+    /// <summary>Left margin.</summary>
     public float MarginLeft { get; set; }
+    /// <summary>Right margin.</summary>
     public float MarginRight { get; set; }
+    /// <summary>Bottom margin.</summary>
     public float MarginBottom { get; set; }
+    /// <summary>Top margin.</summary>
     public float MarginTop { get; set; }
+    /// <summary>Information about individual pages.</summary>
     public System.Collections.Generic.Dictionary<int, PdfPageDetails> Pages { get; } = new();
 }
 

--- a/Sources/PSWritePDF/Support/PdfDocumentOptions.cs
+++ b/Sources/PSWritePDF/Support/PdfDocumentOptions.cs
@@ -2,10 +2,15 @@ using System;
 
 namespace PSWritePDF;
 
+/// <summary>Defines margin settings for a PDF document.</summary>
 public class PdfDocumentOptions
 {
+    /// <summary>Left margin in points.</summary>
     public float? MarginLeft { get; set; }
+    /// <summary>Right margin in points.</summary>
     public float? MarginRight { get; set; }
+    /// <summary>Top margin in points.</summary>
     public float? MarginTop { get; set; }
+    /// <summary>Bottom margin in points.</summary>
     public float? MarginBottom { get; set; }
 }

--- a/Sources/PSWritePDF/Support/PdfExtractionStrategyName.cs
+++ b/Sources/PSWritePDF/Support/PdfExtractionStrategyName.cs
@@ -2,6 +2,7 @@ using iText.Kernel.Pdf.Canvas.Parser.Listener;
 
 namespace PSWritePDF;
 
+/// <summary>Defines text extraction strategies for PDFs.</summary>
 public enum PdfExtractionStrategyName
 {
     Simple,

--- a/Sources/PSWritePDF/Support/PdfFontEncoding.cs
+++ b/Sources/PSWritePDF/Support/PdfFontEncoding.cs
@@ -1,5 +1,6 @@
 namespace PSWritePDF;
 
+/// <summary>Represents encoding options for PDF fonts.</summary>
 public enum PdfFontEncoding
 {
     None,

--- a/Sources/PSWritePDF/Support/PdfFormFieldInfo.cs
+++ b/Sources/PSWritePDF/Support/PdfFormFieldInfo.cs
@@ -1,7 +1,11 @@
 namespace PSWritePDF;
 
+/// <summary>Represents a PDF form field and its name.</summary>
 public class PdfFormFieldInfo
 {
+    /// <summary>Name of the field.</summary>
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>The underlying form field object.</summary>
     public iText.Forms.Fields.PdfFormField Field { get; set; } = null!;
 }

--- a/Sources/PSWritePDF/Support/PdfVersionName.cs
+++ b/Sources/PSWritePDF/Support/PdfVersionName.cs
@@ -1,5 +1,6 @@
 namespace PSWritePDF;
 
+/// <summary>Lists supported PDF specification versions.</summary>
 public enum PdfVersionName
 {
     PDF_1_0,


### PR DESCRIPTION
## Summary
- document all cmdlets with summaries, parameter descriptions, examples and links
- add type documentation for helper objects
- enforce documentation checks via `-strict`

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj -c Release`
- ⚠️ `Invoke-Pester -Script Tests -Output Detailed` *(failed: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_6896413b0c60832e9752f820e44c9dd6