### PR TITLE
Ensure mandatory path parameters are not empty

### DIFF
--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertHTMLToPDF.cs
@@ -52,10 +52,12 @@ public class CmdletConvertHTMLToPDF : AsyncPSCmdlet
 
     /// <summary>Path to an HTML file.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.File)]
+    [ValidateNotNullOrEmpty]
     public string FilePath { get; set; }
 
     /// <summary>Output PDF path.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string OutputFilePath { get; set; }
 
     /// <summary>Open the PDF after creation.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletConvertPDFToText.cs
@@ -40,6 +40,7 @@ public class CmdletConvertPDFToText : PSCmdlet
     /// <summary>Path to the PDF file.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     [Alias("FullName")]
+    [ValidateNotNullOrEmpty]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Pages to extract.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletGetPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletGetPDF.cs
@@ -35,6 +35,7 @@ public class CmdletGetPDF : PSCmdlet
 {
     /// <summary>Path to the PDF file.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [ValidateNotNullOrEmpty]
     public string FilePath { get; set; } = null!;
 
     /// <summary>Ignore document protection.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletMergePDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletMergePDF.cs
@@ -35,10 +35,12 @@ public class CmdletMergePDF : PSCmdlet
 {
     /// <summary>Paths to PDF files to merge.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string[] InputFile { get; set; }
 
     /// <summary>Path for the merged output.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string OutputFile { get; set; }
 
     /// <summary>Ignore protection on input files.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDF.cs
@@ -40,6 +40,7 @@ public class CmdletNewPDF : PSCmdlet {
 
     /// <summary>Output file path.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>PDF version to use.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletNewPDFImage.cs
@@ -33,6 +33,7 @@ namespace PSWritePDF.Cmdlets;
 public class CmdletNewPDFImage : PSCmdlet {
     /// <summary>Path to the image file.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string ImagePath { get; set; } = string.Empty;
     /// <summary>Desired image width.</summary>
     [Parameter] public int Width { get; set; }

--- a/Sources/PSWritePDF/Cmdlets/CmdletRegisterPDFFont.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletRegisterPDFFont.cs
@@ -40,6 +40,7 @@ public class CmdletRegisterPDFFont : PSCmdlet
 
     /// <summary>Path to the font file.</summary>
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
     public string FontPath { get; set; } = string.Empty;
 
     /// <summary>Optional encoding for the font.</summary>

--- a/Sources/PSWritePDF/Cmdlets/CmdletSplitPDF.cs
+++ b/Sources/PSWritePDF/Cmdlets/CmdletSplitPDF.cs
@@ -41,12 +41,14 @@ public class CmdletSplitPDF : PSCmdlet
     [Parameter(Mandatory = true, ParameterSetName = SplitCountParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = PageRangeParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = BookmarkParameterSet)]
+    [ValidateNotNullOrEmpty]
     public string FilePath { get; set; }
 
     /// <summary>Destination folder for split files.</summary>
     [Parameter(Mandatory = true, ParameterSetName = SplitCountParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = PageRangeParameterSet)]
     [Parameter(Mandatory = true, ParameterSetName = BookmarkParameterSet)]
+    [ValidateNotNullOrEmpty]
     public string OutputFolder { get; set; }
 
     /// <summary>Base name for output files.</summary>


### PR DESCRIPTION
## Summary
- guard mandatory path parameters with `[ValidateNotNullOrEmpty]` in cmdlets

## Testing
- `dotnet build`
- `pwsh -NoLogo -NoProfile -File ./PSWritePDF.Tests.ps1` *(fails: ParameterBindingException in Convert-PDFToText tests)*

------
https://chatgpt.com/codex/tasks/task_e_6896f189a928832e8edcbd4f6e21544f