### PR TITLE
Fix Pester tests for Convert-PDFToText and form cleanup

### DIFF
--- a/Tests/Convert-PDFToText.Tests.ps1
+++ b/Tests/Convert-PDFToText.Tests.ps1
@@ -1,8 +1,8 @@
 Describe 'Convert-PDFToText' {
     It 'returns objects with PageNumber and Text' {
-        $file = Join-Path $PSScriptRoot 'Input' 'SampleAcroForm.pdf'
+        $file = [IO.Path]::Combine($PSScriptRoot, 'Input', 'SampleAcroForm.pdf')
         $text = Convert-PDFToText -FilePath $file
-        $text | Should -AllBeOfType [pscustomobject]
+        $text | ForEach-Object { $_ | Should -BeOfType [psobject] }
         $text[0].PageNumber | Should -Be 1
         $text[0].Text | Should -Match 'Text 1'
     }

--- a/Tests/Set-PDFForm.Tests.ps1
+++ b/Tests/Set-PDFForm.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Set-PDFForm' -Tags "PDFForm" {
     BeforeAll {
-        New-Item -Path $PSScriptRoot -Force -ItemType Directory -Name 'Output'
+        New-Item -Path $PSScriptRoot -Force -ItemType Directory -Name 'Output' | Out-Null
     }
 
     It 'Set-PDForm Flatten should flatten forms' {
@@ -115,10 +115,12 @@ Describe 'Set-PDFForm' -Tags "PDFForm" {
         Close-PDF -Document $PDF
     }
 
-    # cleanup
-    $FolderPath = [IO.Path]::Combine("$PSScriptRoot", "Output")
-    $Files = Get-ChildItem -LiteralPath $FolderPath -File
-    foreach ($_ in $Files) {
-        Remove-Item -LiteralPath $_.FullName -ErrorAction SilentlyContinue
+    AfterAll {
+        $FolderPath = [IO.Path]::Combine("$PSScriptRoot", "Output")
+        if (Test-Path $FolderPath) {
+            Get-ChildItem -LiteralPath $FolderPath -File | ForEach-Object {
+                Remove-Item -LiteralPath $_.FullName -ErrorAction SilentlyContinue
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Convert-PDFToText test uses proper type assertions
- move Set-PDFForm test cleanup to AfterAll and avoid discovery errors

## Testing
- `dotnet build Sources/PSWritePDF/PSWritePDF.csproj -c Debug -v minimal --nologo`
- `pwsh -NoLogo -File ./PSWritePDF.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689702510464832e9469bd37e0e08091